### PR TITLE
fix(PsrAdapter) + bench/compare harness improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,109 @@ read alongside the wins.
 
 ## Unreleased
 
+### Post-merge corrections
+
+Items landed after the optimisation branch merged to `master`:
+
+#### Fixed (early post-merge)
+
+- **Unrouteable URLs return 404, not 500.** When the convention
+  router resolved a URL to a class that didn't exist, the
+  `ContainerException` from `$container->get($controller_ref)`
+  bubbled up to the renderer as a 500. From the client's
+  perspective that's still "no such resource"; `App::dispatch`
+  now catches the resolution failure and rethrows as
+  `NotFoundException` (404).
+- **Convention router accepts `v1` (no trailing period).** The
+  shape was tightened in the optimisation branch in a way that
+  TypeError'd on the no-period form. Restored.
+- **Boot is database-free again.** `Service\Registry` used to be
+  eagerly resolved during `App::__construct`, forcing a MySQL
+  connection on every request — including 404s and `/health`
+  checks. Registry is now lazy: only the legacy `Model\Record` /
+  `Data\Map` consumers pull it, and only when actually used.
+
+#### Refactored (early post-merge)
+
+- **`davidwyly/rxn-orm` moved from `require` to `suggest`.** Apps
+  using Rxn purely for routing / DTO binding / middleware no
+  longer pull in the ORM. The framework's `Database::run()` and
+  `Model\ActiveRecord` type-hint `\Rxn\Orm\Builder\Buildable` /
+  `\Rxn\Orm\Builder\Query`, which (per principle 11) only resolve
+  when the methods are actually called — so the framework still
+  loads cleanly without rxn-orm installed.
+- **`Psr16IdempotencyStore` drops duck-typing.** Replaced the
+  `object` parameter + `method_exists` validation with a nominal
+  `\Psr\SimpleCache\CacheInterface` type-hint. PHP's lazy
+  autoload of typed parameters means the framework still loads
+  cleanly without `psr/simple-cache` installed; reviewers see a
+  normal type-hint, no docblock gymnastics.
+
+#### Added
+
+- **`Response::problem(int $code, ?string $title, ?string $detail,
+  ?array $validationErrors)`** — public factory for building an
+  RFC 7807 Problem Details response without going through an
+  exception. Used by middleware that needs to short-circuit with a
+  structured failure (auth, rate limit, idempotency conflict).
+- **`docs/psr-7-interop.md`** — owns the dual-stack story: why
+  the framework is PSR-15-bridged rather than PSR-7-native (the
+  Nyholm `with*()` clone-chain measurement, principle 4's "don't
+  import PHP overhead you can't compile away," JSON-only
+  narrowing) and when each stack is the right tool.
+
+#### Fixed
+
+- **`BearerAuth` 401 responses now actually emit
+  `application/problem+json`.** Pre-fix, the middleware reached
+  into `Response`'s private `$code` via reflection and populated
+  `meta` (not `errors`), so `App::render` saw `isError() === false`
+  and emitted a regular JSON envelope — silently violating the
+  framework's RFC 7807 commitment for the auth path. The
+  middleware now goes through `Response::problem()` and the wire
+  shape matches every other failure path.
+- **Malformed route placeholders fail at registration.** Patterns
+  like `/{1bad:int}`, `/{na-me:int}`, or `/u/{:int}` previously
+  fell through to `preg_quote` and silently became literal
+  segments — registering an unmatchable static route the user
+  never intended. Now `\InvalidArgumentException` is thrown with a
+  message explaining the expected `{name}` / `{name:type}` grammar.
+
+  *Breaking* for anyone whose codebase contains a typo of this
+  shape (the route never matched anything, but registration used
+  to succeed). Pre-1.0 so within the SemVer window.
+
+#### Test coverage
+
+- New parametric `BinderMatrixTest` runs 14 cells of
+  (type × required × default × nullable × attribute) through both
+  `Binder::bind` and `Binder::compileFor` and asserts identical
+  outcomes. Locks the runtime/compiled paths against drift.
+- New `RouterTest` adversarial-pattern data provider covers nine
+  malformed / edge-case patterns; this is what surfaced the
+  silent-literal-segment bug above.
+- `OpenApi\GeneratorTest` snapshot test pins three controller
+  paths and the Problem Details schema shape, so any drift in the
+  reflection-driven generator becomes a deliberate diff.
+- `BearerAuthTest::testMissingHeaderReturns401` updated to
+  validate the new `application/problem+json` shape end-to-end.
+
+#### Docs
+
+- `docs/design-philosophy.md` — corrected the "~3,000 LOC"
+  reference to "~10k LOC, ~3k LOC dispatch spine" (with the spine
+  enumerated). Added a "Per-request state is sync-only by design"
+  subsection making the framework's stated sync-first posture
+  explicit at the middleware-static layer.
+- `docs/psr-7-interop.md` — see *Added* above; documents the
+  dual-stack story.
+- README — promoted explicit / attribute routing as the
+  recommended surface in the dispatch diagram and Features list;
+  convention router still supported, demoted to a "legacy path"
+  note.
+
+### Optimisation branch (`claude/code-review-pDtRd`)
+
 This is the largest single span of work in the repo's history:
 27 merged commits across performance, framework breadth, and docs,
 all on `claude/code-review-pDtRd`. Headline items below; the full
@@ -62,11 +165,14 @@ state for long-lived workers).
     using atomic `fopen('xb')` lock + atomic rename writes; zero
     new dependencies
   - `Http\Idempotency\Psr16IdempotencyStore` — bridge to **any**
-    PSR-16-shaped cache **without** importing PSR-16. Constructor
-    parameter declared `object`, validated structurally via
-    `method_exists`. Apps already running Redis through
-    `symfony/cache` / `cache/redis-adapter` / etc. drop their
-    cache in directly with one line and no adapter to write.
+    PSR-16-shaped cache. Constructor type-hints
+    `\Psr\SimpleCache\CacheInterface` directly; PHP's lazy autoload
+    of typed parameters means the framework still loads cleanly
+    when `psr/simple-cache` isn't installed (the file sits inert
+    until something actually instantiates it). See "principle 11"
+    in `docs/design-philosophy.md` for the pattern. Apps already
+    running Redis through `symfony/cache` /
+    `cache/redis-adapter` / etc. drop their cache in directly.
 - **`Http\Middleware\Pagination`** — parses `?limit=&offset=` or
   `?page=&per_page=` into a typed `Pagination` value object;
   emits `X-Total-Count` and RFC 8288 `Link: rel=...` headers

--- a/README.md
+++ b/README.md
@@ -30,19 +30,20 @@ in automatically via Composer.
 ```mermaid
 flowchart TB
     Req["HTTP request"] --> Index["public/index.php"]
-    Index --> App["App::run"]
-    App --> Boot["Startup<br/>.env + autoload + DBs"]
-    App --> Dispatch{"route?"}
-    Dispatch -->|convention| ConvCtrl["Versioned controller"]
-    Dispatch -->|explicit| Router["Http/Router"]
+    Index --> Router["Http/Router<br/>(explicit or attribute-driven)"]
     Router --> Pipeline["Middleware pipeline"]
-    Pipeline --> ExplCtrl["Route handler"]
-    ConvCtrl --> Resp["Response"]
-    ExplCtrl --> Resp
+    Pipeline --> Handler["Route handler<br/>+ DTO bind/validate"]
+    Handler --> Resp["Response"]
     Resp -->|success| OK["application/json<br/>{data, meta}"]
     Resp -. uncaught exception .-> Fail["Response::getFailure"]
     Fail --> PD["application/problem+json<br/>RFC 7807"]
 ```
+
+The recommended dispatch shape is the explicit `Http\Router` — driven
+directly, or populated from `#[Route]` attributes via
+`Http\Attribute\Scanner`. A legacy convention router
+(`App::run` matching `/v{N}/{controller}/{action}/...`) is still
+shipped for older apps; see [`docs/routing.md`](docs/routing.md).
 
 See [`docs/index.md`](docs/index.md) for the full request sequence
 and per-subsystem deep dives.
@@ -287,6 +288,7 @@ methodology is in
 | Scaffolded CRUD | [`docs/scaffolding.md`](docs/scaffolding.md) |
 | Error handling | [`docs/error-handling.md`](docs/error-handling.md) |
 | Building blocks (Logger, RateLimiter, Scheduler, Auth, Pipeline, Router, Validator, Migration, Chain, query cache, PSR-7 bridge) | [`docs/building-blocks.md`](docs/building-blocks.md) |
+| PSR-7 / PSR-15 interop — why the framework is bridged not native, and when each stack applies | [`docs/psr-7-interop.md`](docs/psr-7-interop.md) |
 | CLI (`bin/rxn`) | [`docs/cli.md`](docs/cli.md) |
 | Benchmarks (`bin/bench`) | [`docs/benchmarks.md`](docs/benchmarks.md) |
 | Cross-framework comparison (Slim / Symfony / raw) | [`bench/compare/README.md`](bench/compare/README.md) |
@@ -335,17 +337,23 @@ methodology is in
          members
 - [X] Versioning (versioned controllers + actions)
 - [X] Scaffolding (version-less CRUD against a live schema)
-- [X] URI Routing
-   - [X] Convention-based (`/v{N}/{controller}/{action}/key/value/...`)
-   - [X] Explicit pattern routing (`Rxn\Framework\Http\Router`)
-   - [X] Typed route constraints (`{id:int}`, `{slug:slug}`,
-         `{id:uuid}`, custom) — a non-matching URL just falls
-         through to 404 instead of bubbling up as a controller-level
-         validation error
+- [X] URI Routing — **explicit `Http\Router` is the recommended
+      surface**, driven directly or populated from `#[Route]`
+      attributes
    - [X] Attribute-based routing — `#[Route('GET', '/products/{id:int}')]`
          + `#[Middleware(Auth::class)]` directly on controller methods
          via `Rxn\Framework\Http\Attribute\Scanner`; no separate
          route table
+   - [X] Explicit pattern routing (`Rxn\Framework\Http\Router`) when
+         attributes don't fit (programmatic groups, route generation
+         from data, etc.)
+   - [X] Typed route constraints (`{id:int}`, `{slug:slug}`,
+         `{id:uuid}`, custom) — a non-matching URL just falls
+         through to 404 instead of bubbling up as a controller-level
+         validation error
+   - [X] Convention-based (`/v{N}/{controller}/{action}/key/value/...`)
+         — legacy path retained for older apps; new code should use
+         attribute or explicit routing
    - [X] Apache 2 (.htaccess)
    - [X] NGINX (see `docker/nginx`)
 - [X] Dependency Injection container

--- a/bench/compare/load.php
+++ b/bench/compare/load.php
@@ -29,15 +29,16 @@ final class Load
      *   headers: array<int, string>
      * } $request
      * @return array{
-     *   count:    int,
-     *   errors:   int,
-     *   non_2xx:  int,
-     *   elapsed:  float,
-     *   rps:      float,
-     *   p50_ms:   float,
-     *   p99_ms:   float,
-     *   max_ms:   float,
-     *   status_breakdown: array<int, int>
+     *   count:               int,
+     *   errors:              int,
+     *   non_2xx:             int,
+     *   elapsed:             float,
+     *   rps:                 float,
+     *   rps_median_window:   float,
+     *   p50_ms:              float,
+     *   p99_ms:              float,
+     *   max_ms:              float,
+     *   status_breakdown:    array<int, int>
      * }
      */
     public static function run(array $request, int $concurrency, float $duration): array
@@ -73,8 +74,18 @@ final class Load
         $errors         = 0;
         $non2xx         = 0;
         $statusCounts   = [];
-        $deadline       = microtime(true) + $duration;
+        $runStart       = microtime(true);
+        $deadline       = $runStart + $duration;
         $running        = $concurrency;
+        // Bin completions into 100ms windows so we can report the
+        // median windowed rps in addition to the simple count/duration
+        // value. The simple rps is sensitive to brief stalls (a 1s
+        // stall in a 7s run costs 14% rps); the median windowed rps
+        // is robust to short bursts and tells you "what was the rate
+        // a typical 100ms slice of this run saw" — closer to what
+        // you'd see at steady state on a clean rig.
+        $windowMs       = 100;
+        $windowCounts   = [];
 
         while (true) {
             do {
@@ -88,6 +99,9 @@ final class Load
                 $end  = microtime(true);
                 $start = $slots[$hid] ?? $end;
                 $latencies[] = ($end - $start) * 1000.0; // ms
+
+                $bin = (int) (($end - $runStart) * 1000 / $windowMs);
+                $windowCounts[$bin] = ($windowCounts[$bin] ?? 0) + 1;
 
                 if ($info['result'] !== CURLE_OK) {
                     $errors++;
@@ -141,18 +155,33 @@ final class Load
         $p99 = self::percentile($latencies, 0.99);
         $max = $latencies !== [] ? end($latencies) : 0.0;
 
+        // Median windowed rps: drop the first and last bins (partially
+        // populated at run boundaries — first bin starts mid-warmup,
+        // last bin ends mid-tick) and take the median of the rest.
+        // Multiplied to req/sec from req/100ms.
+        $rpsMedianWindow = 0.0;
+        if (count($windowCounts) > 2) {
+            ksort($windowCounts);
+            $bins = array_values($windowCounts);
+            $bins = array_slice($bins, 1, -1);
+            sort($bins);
+            $mid = $bins[(int) (count($bins) / 2)];
+            $rpsMedianWindow = $mid * (1000.0 / $windowMs);
+        }
+
         ksort($statusCounts);
 
         return [
-            'count'            => $count,
-            'errors'           => $errors,
-            'non_2xx'          => $non2xx,
-            'elapsed'          => $elapsed,
-            'rps'              => $elapsed > 0 ? $count / $elapsed : 0.0,
-            'p50_ms'           => $p50,
-            'p99_ms'           => $p99,
-            'max_ms'           => $max,
-            'status_breakdown' => $statusCounts,
+            'count'             => $count,
+            'errors'            => $errors,
+            'non_2xx'           => $non2xx,
+            'elapsed'           => $elapsed,
+            'rps'               => $elapsed > 0 ? $count / $elapsed : 0.0,
+            'rps_median_window' => $rpsMedianWindow,
+            'p50_ms'            => $p50,
+            'p99_ms'            => $p99,
+            'max_ms'            => $max,
+            'status_breakdown'  => $statusCounts,
         ];
     }
 

--- a/bench/compare/load.php
+++ b/bench/compare/load.php
@@ -44,7 +44,24 @@ final class Load
     {
         $multi = curl_multi_init();
 
-        // Slot table: [handle => start_time] for the in-flight handles.
+        // Pre-allocate one handle per slot and reuse it for the whole
+        // run. The earlier shape closed-and-recreated a handle per
+        // request, which destroyed curl's connection cache and forced
+        // a fresh TCP socket per request — at 17k rps × concurrency
+        // that depletes the ephemeral port pool (~28k ports, TIME_WAIT
+        // holds them) within seconds and the bench windows hit
+        // periodic port-pressure stalls.
+        //
+        // **Caveat for `php -S`**: the built-in CLI server always
+        // emits `Connection: close`, so even with handle reuse the
+        // server tears down the TCP socket after every response.
+        // Real connection reuse only happens for the small fraction
+        // of requests where curl re-arms before the kernel has
+        // observed FIN. Under `php -S` this fix mitigates but does
+        // not eliminate the port-pressure stall pattern. Under any
+        // server with HTTP/1.1 keep-alive (FrankenPHP, RoadRunner,
+        // PHP-FPM behind nginx) the fix is fully effective and pins
+        // open-socket count at ~$concurrency for the whole run.
         $slots = [];
         for ($i = 0; $i < $concurrency; $i++) {
             $h = self::makeHandle($request);
@@ -86,16 +103,19 @@ final class Load
                     }
                 }
 
+                // Remove the handle from the multi, but don't close
+                // it — re-arm and re-add so the next request reuses
+                // the underlying TCP connection. The handle keeps
+                // its options (URL, method, body, headers) across
+                // remove/add cycles.
                 curl_multi_remove_handle($multi, $h);
-                curl_close($h);
-                unset($slots[$hid]);
-
-                // Refill the slot if we still have time on the clock.
                 if (microtime(true) < $deadline) {
-                    $newH = self::makeHandle($request);
-                    curl_multi_add_handle($multi, $newH);
-                    $slots[(int) $newH] = microtime(true);
+                    $slots[$hid] = microtime(true);
+                    curl_multi_add_handle($multi, $h);
                     $running++;
+                } else {
+                    curl_close($h);
+                    unset($slots[$hid]);
                 }
             }
 
@@ -108,6 +128,9 @@ final class Load
             curl_multi_select($multi, 0.05);
         }
 
+        // All handles get closed in the else-branch above as they
+        // complete past the deadline; $running can't reach 0 until
+        // every active handle has been removed and closed.
         curl_multi_close($multi);
 
         $count   = count($latencies);

--- a/bench/compare/run.php
+++ b/bench/compare/run.php
@@ -178,8 +178,9 @@ foreach ($opts['frameworks'] as $name) {
             // worker pool and time out spuriously.
             usleep(250_000);
             fwrite(STDERR, sprintf(
-                "%8s rps (p50 %5.2f ms / p99 %6.2f ms)\n",
+                "%8s rps (median-window %s) (p50 %5.2f ms / p99 %6.2f ms)\n",
                 number_format($r['rps'], 0),
+                number_format($r['rps_median_window'], 0),
                 $r['p50_ms'],
                 $r['p99_ms']
             ));
@@ -350,7 +351,7 @@ function render_markdown(array $results, array $opts): string
         $opts['host']
     );
     $lines[] = '';
-    $lines[] = '## Throughput (req/s — higher is better)';
+    $lines[] = '## Throughput — count / duration (req/s — higher is better)';
     $lines[] = '';
     $lines[] = '| Framework | ' . implode(' | ', $routeNames) . ' |';
     $lines[] = '|---|' . str_repeat('---:|', count($routeNames));
@@ -362,6 +363,23 @@ function render_markdown(array $results, array $opts): string
                 $cells[] = $r['error'] ?? '—';
             } else {
                 $cells[] = number_format($r['rps'], 0);
+            }
+        }
+        $lines[] = '| `' . $fw . '` | ' . implode(' | ', $cells) . ' |';
+    }
+    $lines[] = '';
+    $lines[] = '## Throughput — median 100ms-window (req/s — robust to brief stalls, use this for A/B)';
+    $lines[] = '';
+    $lines[] = '| Framework | ' . implode(' | ', $routeNames) . ' |';
+    $lines[] = '|---|' . str_repeat('---:|', count($routeNames));
+    foreach ($results as $fw => $perRoute) {
+        $cells = [];
+        foreach ($routeNames as $rn) {
+            $r = $perRoute[$rn] ?? null;
+            if (!is_array($r) || isset($r['error'])) {
+                $cells[] = $r['error'] ?? '—';
+            } else {
+                $cells[] = number_format($r['rps_median_window'], 0);
             }
         }
         $lines[] = '| `' . $fw . '` | ' . implode(' | ', $cells) . ' |';

--- a/docs/design-philosophy.md
+++ b/docs/design-philosophy.md
@@ -113,25 +113,37 @@ Articulated as a rule: **schema-compile what's in PHP; never
 try to outrun a C extension from PHP.** That rule is what saved
 us from spending more time chasing a CompiledJson v2.
 
-## 5. Convention defaults; explicit escape hatches
+## 5. Common case at zero cost; explicit escape hatches
+
+The shape: pick the path that needs the *least* configuration for
+the most common job, and provide an escape hatch when the
+defaults stop fitting.
+
+For routing, that has shifted with the framework's identity. The
+modern default — and what the README and `examples/products-api`
+lead with — is **explicit `Http\Router`**, populated either
+programmatically or from `#[Route]` attributes via
+`Http\Attribute\Scanner`. The headline "FastAPI-class DTO +
+attribute routing + reflection-driven OpenAPI" pitch wants the
+attribute path front and centre:
 
 ```php
-// Convention routing — zero config:
-//   GET /v1/user/show  →  app/Http/Controller/v1/UserController::show_v1()
-
-// Explicit Router — when you outgrow the convention:
-$router = new Router();
-$router->get('/products/{id:int}', ProductController::class . '::show')
-       ->name('products.show')
-       ->middleware($auth);
+final class ProductController {
+    #[Route('GET', '/products/{id:int}')]
+    #[Middleware(BearerAuth::class)]
+    public function show(int $id): array { ... }
+}
 ```
 
-Convention covers the common case at zero cost — no router config,
-no DSL to learn. The explicit `Router` is there when you need
-named routes, middleware groups, custom URL generation. **You
-don't pay for the explicit router until you need it.**
+A **convention router** also ships (`/v{N}/{controller}/{action}/...`
+parsed from `$_GET` into `App::run`). It's older than the
+explicit Router and is preserved for apps that already depend on
+it, but it isn't the recommended path for new code — attribute /
+explicit routing matches the framework's marketing identity and
+the example app.
 
-The same pattern shows up everywhere:
+The same "common case at zero cost" pattern shows up across the
+framework:
 
 - **Container** — autowiring is the default; `bind($abstract, $concrete)`
   is the escape hatch for interfaces / factories.
@@ -139,8 +151,9 @@ The same pattern shows up everywhere:
   (`fn ($v, $f): ?string`) cover the rest.
 - **Binder** — public typed properties + `#[Required]` cover most
   DTOs; custom `Validates` attributes cover the rest.
-- **Pipeline** — `add($middleware)` is the API; building your own
-  PSR-15-compatible runner is the escape hatch (`Psr15Pipeline`).
+- **Pipeline** — `add($middleware)` is the API; the PSR-15 stack
+  (`Psr15Pipeline`) is the escape hatch when you need ecosystem
+  middleware (see [`psr-7-interop.md`](psr-7-interop.md)).
 
 **Ergonomics for the common case, escape hatches for the rare.**
 
@@ -212,7 +225,11 @@ to read is slow to *develop in*. Time-to-first-bug-fixed is a
 real metric.
 
 Rxn fits in your head:
-- The whole framework is ~3,000 LOC of PHP excluding tests.
+- The framework is ~10k LOC of PHP excluding tests; the dispatch
+  spine — Container, Router, Pipeline, Binder, Validator,
+  Request, Response — is ~3k of that, readable in one sitting.
+  Middlewares, OpenAPI, scaffolding, and the legacy ActiveRecord
+  layer make up the rest and don't sit on the hot path.
 - One mental model (request → router → pipeline → controller →
   response) covers the request lifecycle.
 - One error envelope (RFC 7807) covers every failure mode.
@@ -339,10 +356,34 @@ principles are how we keep the substrate healthy.
 | 5 — convention + escape hatch | `App::run` convention router → `Http\Router` explicit; `Container` autowire → `bind()` |
 | 6 — measure to commit | `bench/ab.php` driver, 16 experiment writeups, 4 negative-result branches preserved on origin |
 | 7 — transparent vs visible opt-in | Container's 5 stacked caches: zero API change. `Validator::compile`: visible because of the FPM tradeoff |
-| 8 — smallness as constraint | ~3,000 LOC of framework code; whole framework readable in an afternoon |
+| 8 — smallness as constraint | ~10k LOC framework, ~3k LOC dispatch spine (Container, Router, Pipeline, Binder, Validator, Request, Response) — readable in one sitting; the rest is opt-in subsystems |
 | 9 — ergonomics are performance | `bin/preload.php`, `bench/ab/CONSOLIDATION.md`, `docs/index.md`'s topic table |
 | 10 — honesty | "alpha" status in README, `App::run` open-bugs note in `docs/benchmarks.md`, the long-lived-worker caveat in every compile-path docstring |
 | 11 — optional deps via lazy autoload | `Psr16IdempotencyStore` (typehints `\Psr\SimpleCache\CacheInterface`) and `Database::run()` / `ActiveRecord` (typehint `\Rxn\Orm\Builder\Buildable` / `Query`); both packages live in `composer.json`'s `suggest` block, framework loads cleanly without them |
+
+## Per-request state is sync-only by design
+
+`BearerAuth::current()` and `RequestId::current()` publish state
+through a `private static ?T $current` slot, set on `handle()`
+entry and cleared in `finally`. This is correct under any
+**synchronous** dispatch — including Swoole's default I/O-hooked
+fibers, where request handlers don't `Fiber::suspend()` between
+the set and the clear, so the static is observed only by the
+running request's own downstream code.
+
+The shape is deliberate. The README's stated position is *"sync-
+first, process-per-request, predictable. We deliberately don't
+chase async."* Adding a per-fiber context map (one of the
+"obvious" robustness changes) would import shape the framework
+explicitly opts out of, for a hazard that only triggers when a
+handler holds principal across an explicit `Fiber::suspend()` —
+not a usage pattern the framework endorses or supports.
+
+If you have a handler that explicitly suspends a fiber while
+holding state, propagate that state yourself; don't rely on
+`current()`. This is the same boundary `rxn-orm` draws with
+`Record::clearConnections()` for fiber-isolated connection
+binding.
 
 ## Anti-patterns we deliberately avoid
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -68,6 +68,7 @@ sequenceDiagram
 | [Scaffolding](scaffolding.md) | Auto-CRUD endpoints against a live schema |
 | [Error handling](error-handling.md) | Exceptions + RFC 7807 Problem Details |
 | [Building blocks](building-blocks.md) | Pipeline + shipped middlewares, Logger, RateLimiter, Scheduler, Auth, Migration, Chain, TestClient, SwaggerUi |
+| [PSR-7 / PSR-15 interop](psr-7-interop.md) | Why the framework is PSR-15-bridged rather than PSR-7-native, and when each stack is the right choice |
 | [CLI](cli.md) | `bin/rxn` — migrations, scaffolding, OpenAPI spec |
 | [Benchmarks](benchmarks.md) | `bin/bench` — microbenchmarks for the building blocks |
 | [OPcache preload](opcache-preload.md) | `bin/preload.php` — pre-compile the framework at fpm boot |

--- a/docs/psr-7-interop.md
+++ b/docs/psr-7-interop.md
@@ -1,0 +1,187 @@
+# PSR-7 / PSR-15 interop
+
+Rxn is **PSR-15-bridged, not PSR-7-native**, deliberately. This is
+the most-questioned design decision in the framework, so this
+document is its receipts.
+
+## The two stacks
+
+| Stack | Request shape | Pipeline | Middleware interface | When to use |
+|---|---|---|---|---|
+| **Native** (default) | `Rxn\Framework\Http\Request` (custom) | `Http\Pipeline` | `Rxn\Framework\Http\Middleware` (`handle(Request, callable): Response`) | Default. The throughput numbers in the README live here. |
+| **PSR-15** (escape hatch) | `Psr\Http\Message\ServerRequestInterface` | `Http\Psr15Pipeline` | `Psr\Http\Server\MiddlewareInterface` (PSR-15) | When you need ecosystem PSR-15 middleware (CORS, OAuth, OpenTelemetry, ...) that doesn't have a native equivalent. |
+
+A single dispatch chooses one or the other. They don't compose
+inside the same pipeline. This is the same shape principle 5 —
+"convention default, explicit escape hatch" — applies to the HTTP
+shape itself.
+
+## Why native is the default
+
+Three reasons, recorded in the codebase:
+
+### 1. PSR-7's immutable-builder pattern is allocation-heavy
+
+The PSR-7 fast-from-globals experiment
+([`bench/ab/experiments/2026-04-29-psr-fast-from-globals.md`](../bench/ab/experiments/2026-04-29-psr-fast-from-globals.md))
+measured Nyholm's `ServerRequestCreator::fromGlobals()` directly:
+
+> For a typical request that's:
+> - Uri: 1 base + 4–5 with*() clones (scheme/host/port/path/query)
+> - ServerRequest: 1 base + 1 clone per header (`withAddedHeader`)
+>   + 1 protocol-version + 1 cookies + 1 query + 1 parsedBody + 1
+>   uploaded-files
+>
+> ≈ 15+ allocations. Most of them write a single private property
+> that the constructor could have set in the first place.
+
+That's just construction, before any middleware step has run. Each
+`with*()` middleware step does another `clone`. Going PSR-7-native
+means paying that overhead on every request and every middleware
+step. The experiment netted **+124%** by going around it for the
+one place we do build a PSR-7 request.
+
+### 2. Principle 4 generalises this
+
+[`design-philosophy.md#4`](design-philosophy.md) records:
+
+> Schema-compiling user-space code only beats the baseline when
+> the baseline is also user-space. Don't try to outrun a C
+> extension from PHP.
+
+The dual of that lesson is: **don't import PHP overhead you
+can't compile away.** PSR-7's immutable graph (Uri + Stream +
+UploadedFile + ServerRequest, each with their own `with*()`
+clones) is exactly that kind of overhead. There's nothing for
+`Validator::compile`-style code-gen to remove — the cost is in
+`clone` itself, which is already at C speed and unavoidable in
+the contract. So the framework opts out of the contract for the
+hot path.
+
+### 3. JSON-only narrowing doesn't need PSR-7's generality
+
+PSR-7 carries the apparatus for streamed bodies, content
+negotiation between HTML / JSON / XML / streams, the message-vs-
+server-request distinction, multiple body shapes, and an
+ecosystem of factories per interface. Rxn's commitment
+([principle 1](design-philosophy.md), "opinionated narrowing") is
+**JSON in, JSON out, RFC 7807 errors, period.** Most of PSR-7's
+shape is unused under that commitment, and "we pay for what we
+don't use" is exactly the cost the framework is trying to avoid.
+
+## When the bridge IS the right answer
+
+The PSR-15 path isn't a fallback or a placeholder — it's the
+correct choice when:
+
+- You need ecosystem middleware that doesn't have a native
+  equivalent (`tuupola/cors-middleware`, OpenTelemetry HTTP
+  instrumentation, certain OAuth flows, framework-portable
+  rate limiters, ...).
+- A host hands you a `ServerRequestInterface` already
+  (RoadRunner with the PSR-7 worker, some Swoole bridges) — you
+  don't pay the construction cost.
+- You're writing libraries that should be portable across PHP
+  micro-frameworks.
+
+In all these cases, opt into `Psr15Pipeline` for that route. You
+trade a fraction of the throughput for the interop unlock, and
+the rest of the framework stays unchanged.
+
+## When to pick which
+
+### Use the native stack when
+
+- You want the throughput numbers in the README (the optimised
+  path lives here).
+- Every middleware you need is in
+  `Http\Middleware\` already.
+- You're writing app middleware against `Http\Request` directly
+  and don't need ecosystem PSR-15 components.
+
+### Use the PSR-15 stack when
+
+- You need a specific ecosystem PSR-15 middleware that doesn't
+  exist as a native Rxn one — `php-middlewares/*`,
+  `tuupola/cors-middleware`, OAuth/JWT middlewares, OpenTelemetry
+  HTTP instrumentation, etc.
+- You're plugging Rxn into a host that hands you a
+  `ServerRequestInterface` already (RoadRunner with the
+  PSR-7 worker, some Swoole bridges).
+- You're building libraries that should be portable across PHP
+  micro-frameworks.
+
+The PSR-15 path costs the Nyholm clone chain on construction
+(unless you're handed the request) and an interface check per
+middleware step. On `php -S` micro-benchmarks the difference is
+visible; on FPM-behind-nginx it's typically lost in the noise.
+
+## How to use the PSR-15 stack
+
+```php
+use Rxn\Framework\Http\PsrAdapter;
+use Rxn\Framework\Http\Psr15Pipeline;
+use Psr\Http\Server\RequestHandlerInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+
+$request = PsrAdapter::serverRequestFromGlobals();
+
+$pipeline = (new Psr15Pipeline())
+    ->add(new SomeEcosystemMiddleware())    // any psr/http-server-middleware
+    ->add(new AnotherPsr15Middleware());
+
+// Terminal handler — returns a PSR-7 ResponseInterface.
+$terminal = new class implements RequestHandlerInterface {
+    public function handle(ServerRequestInterface $request): ResponseInterface
+    {
+        // Build your response with PsrAdapter::factory() (Nyholm).
+        return PsrAdapter::factory()
+            ->createResponse(200)
+            ->withHeader('content-type', 'application/json')
+            ->withBody(PsrAdapter::factory()->createStream('{"ok":true}'));
+    }
+};
+
+$response = $pipeline->run($request, $terminal);
+PsrAdapter::emit($response);
+```
+
+`PsrAdapter::factory()` returns Nyholm's PSR-17 factory, which
+implements every PSR-17 interface — use it to construct
+requests, responses, streams, or uploaded files when you need to.
+
+## Crossing the boundary
+
+There is **no automatic adapter** between the two stacks in either
+direction. A PSR-15 middleware cannot run inside `Http\Pipeline`
+unless you write a custom shim, and a native `Http\Middleware`
+cannot run inside `Http\Psr15Pipeline` unless you write the
+inverse shim. This is deliberate: an automatic adapter would have
+to construct a PSR-7 request from `Http\Request` (or vice versa),
+which means walking superglobals on every middleware step and
+defeating the optimisation that motivated the split in the first
+place.
+
+If you find yourself needing both shapes in the same request,
+that's the signal to consolidate on the PSR-15 stack for that
+route — not to bridge mid-pipeline.
+
+## Future work
+
+The dual-stack is **not** a transitional state — it's the design.
+A hypothetical "PSR-7-everywhere" v2 would re-import the
+allocation cost the framework has explicitly chosen to opt out of,
+and there's no code-gen trick to reclaim it (see reason 2 above).
+What's worth doing instead, if interop demand grows:
+
+- A small adapter that wraps a PSR-15 middleware as an
+  `Http\Middleware`, so individual ecosystem components can be
+  used inside the native pipeline (paying PSR-7 construction
+  *only on that step*, not for the whole pipeline).
+- Sharper docs on which native middlewares have ecosystem
+  PSR-15 equivalents and when each is the right call.
+
+Until/unless those land: pick a stack per route, document which
+one you're on, and use this page to settle which side of the
+boundary each piece of middleware lives on.

--- a/src/Rxn/Framework/Http/Middleware/BearerAuth.php
+++ b/src/Rxn/Framework/Http/Middleware/BearerAuth.php
@@ -63,6 +63,15 @@ final class BearerAuth implements Middleware
      * `finally` so a long-lived worker doesn't leak the previous
      * request's principal into the next.
      *
+     * Sync-only by design: the framework targets PHP-FPM's
+     * process-per-request model (see README, "we deliberately don't
+     * chase async"). The clear-in-`finally` pattern is correct under
+     * any sync dispatch — including Swoole's default I/O-hooked
+     * fibers, where request handlers don't `Fiber::suspend()`
+     * between set and clear. If you have a handler that explicitly
+     * suspends a fiber while holding state, propagate the principal
+     * yourself; don't rely on this static.
+     *
      * @return array<string, mixed>|null
      */
     public static function current(): ?array
@@ -72,16 +81,14 @@ final class BearerAuth implements Middleware
 
     private function renderUnauthorized(): Response
     {
-        $r = (new \ReflectionClass(Response::class))->newInstanceWithoutConstructor();
-        $r->setRendered(false);
-        $r->meta = [
-            'type'   => 'unauthorized',
-            'title'  => 'Authentication required',
-            'status' => 401,
-        ];
-        $codeProp = (new \ReflectionClass(Response::class))->getProperty('code');
-        $codeProp->setAccessible(true);
-        $codeProp->setValue($r, 401);
-        return $r;
+        // Goes through the public Problem Details factory so the
+        // 401 lands as `application/problem+json` (matching the
+        // framework's RFC 7807 commitment), instead of leaking
+        // through as an envelope-shaped 401.
+        return Response::problem(
+            code:   401,
+            title:  'Unauthorized',
+            detail: 'Authentication required',
+        );
     }
 }

--- a/src/Rxn/Framework/Http/Middleware/RequestId.php
+++ b/src/Rxn/Framework/Http/Middleware/RequestId.php
@@ -34,6 +34,11 @@ final class RequestId implements Middleware
         return $next($request);
     }
 
+    /**
+     * The correlation id for the current request, or null when the
+     * middleware never ran. Sync-only by design — see the matching
+     * note on `BearerAuth::current()`.
+     */
     public static function current(): ?string
     {
         return self::$current;

--- a/src/Rxn/Framework/Http/PsrAdapter.php
+++ b/src/Rxn/Framework/Http/PsrAdapter.php
@@ -71,13 +71,25 @@ final class PsrAdapter
 
         // ServerRequest's constructor sets method, uri, headers,
         // queryParams (via parse_str on uri.query), protocol, and
-        // serverParams. Body stays deferred until getBody() — same
-        // lazy-stream behaviour as the default builder.
+        // serverParams. Body wraps php://input — Nyholm's default
+        // ServerRequestCreator::fromGlobals does the same — so
+        // request bodies are actually visible to anything that
+        // calls getBody(). Without this, Nyholm's MessageTrait
+        // initialises the stream to an empty in-memory string on
+        // first read, which silently strips POST / PUT / PATCH
+        // payloads — the JSON body never reaches a downstream
+        // middleware or handler.
+        //
+        // fopen('php://input') itself is a cheap descriptor
+        // allocation; the actual read cost lives in
+        // getBody()->getContents() and is paid only when (and if)
+        // something asks for it.
+        $body = \fopen('php://input', 'r') ?: null;
         $request = new ServerRequest(
             $method,
             new Uri($uriString),
             $headers,
-            null,
+            $body,
             $protocol,
             $server,
         );

--- a/src/Rxn/Framework/Http/Response.php
+++ b/src/Rxn/Framework/Http/Response.php
@@ -339,6 +339,45 @@ class Response
     }
 
     /**
+     * Build an RFC 7807 Problem Details response without going
+     * through an exception. Use this in middleware that needs to
+     * short-circuit with a structured failure (auth, rate limit,
+     * idempotency conflict) — the renderer sees `isError()` is
+     * true, picks the `application/problem+json` content type, and
+     * emits the same shape an uncaught exception would have.
+     *
+     * `$title` defaults to the standard reason phrase for `$code`;
+     * `$detail` defaults to empty. Pass per-field validation errors
+     * via `$validationErrors` if you want a 422-shaped `errors[]`
+     * extension member.
+     *
+     * @param list<array{field: string, message: string}>|null $validationErrors
+     */
+    public static function problem(
+        int $code,
+        ?string $title = null,
+        ?string $detail = null,
+        ?array $validationErrors = null,
+    ): self {
+        $r = (new \ReflectionClass(self::class))->newInstanceWithoutConstructor();
+        $r->rendered = true;
+        $r->code     = $code;
+        $r->errors   = [
+            'type'    => $title ?? self::getResponseCodeResult($code),
+            'message' => $detail ?? '',
+        ];
+        if ($validationErrors !== null) {
+            $r->validation_errors = $validationErrors;
+        }
+        $r->meta = [
+            'success'    => false,
+            'code'       => $code,
+            'elapsed_ms' => App::getElapsedMs(),
+        ];
+        return $r;
+    }
+
+    /**
      * True when this response represents a rendered failure — i.e.
      * `getFailure()` has populated `$this->errors`.
      */

--- a/src/Rxn/Framework/Http/Router.php
+++ b/src/Rxn/Framework/Http/Router.php
@@ -341,9 +341,21 @@ final class Router
                     throw new \InvalidArgumentException("Unknown route constraint type '$type'");
                 }
                 $parts[] = '(' . $this->constraints[$type] . ')';
-            } else {
-                $parts[] = preg_quote($segment, '#');
+                continue;
             }
+            // Anything that *looks* like a placeholder (`{...}`) but
+            // doesn't conform to the strict placeholder grammar must
+            // fail loudly — silently quoting it as a literal segment
+            // means a typo like `{1bad:int}` or `{:int}` becomes an
+            // unmatchable static route the user never intended.
+            if (str_starts_with($segment, '{') && str_ends_with($segment, '}')) {
+                throw new \InvalidArgumentException(
+                    "Malformed route placeholder '$segment' in pattern '$pattern' "
+                    . "(expected '{name}' or '{name:type}' with name "
+                    . "matching [a-zA-Z_][a-zA-Z0-9_]*)"
+                );
+            }
+            $parts[] = preg_quote($segment, '#');
         }
         return ['#^/' . implode('/', $parts) . '$#', $params];
     }

--- a/src/Rxn/Framework/Tests/Http/Binding/BinderMatrixTest.php
+++ b/src/Rxn/Framework/Tests/Http/Binding/BinderMatrixTest.php
@@ -1,0 +1,203 @@
+<?php declare(strict_types=1);
+
+namespace Rxn\Framework\Tests\Http\Binding;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use Rxn\Framework\Http\Binding\Binder;
+use Rxn\Framework\Http\Binding\ValidationException;
+use Rxn\Framework\Tests\Http\Binding\Fixture\BindMatrixDto;
+
+/**
+ * Parametric coverage of the (type × required × default × nullable)
+ * matrix the Binder claims to handle, run twice — once through the
+ * runtime `bind()` path, once through the eval-compiled
+ * `compileFor()` path — to lock the two implementations against
+ * drift. The "schema as truth, multiple consumers" claim only
+ * holds if both consumers agree on every cell.
+ */
+final class BinderMatrixTest extends TestCase
+{
+    /**
+     * Minimum bag that satisfies every #[Required] field. Cases
+     * mutate this and assert that bind() / compileFor() produce
+     * matching outcomes.
+     *
+     * @return array<string, mixed>
+     */
+    private static function validBag(): array
+    {
+        return [
+            'rs'        => 'hello',
+            'ri'        => '7',          // string → int cast
+            'rf'        => '3.14',       // string → float cast
+            'rb'        => 'true',       // string → bool cast
+            'sized'     => 'abcd',
+            'atLeast10' => '11',
+            'lowerOnly' => 'abc',
+            'oneOf'     => 'b',
+        ];
+    }
+
+    /**
+     * Each case: [bag, expectErrors] where expectErrors is null
+     * (success) or list of fields that must appear in the
+     * ValidationException's error set.
+     *
+     * @return iterable<string, array{0: array<string, mixed>, 1: ?list<string>}>
+     */
+    public static function cases(): iterable
+    {
+        $base = self::validBag();
+
+        yield 'valid bag → success' => [$base, null];
+
+        // --- required missing ---
+        yield 'required string missing' => [
+            array_diff_key($base, ['rs' => 1]),
+            ['rs'],
+        ];
+        yield 'required int missing' => [
+            array_diff_key($base, ['ri' => 1]),
+            ['ri'],
+        ];
+        yield 'every required missing' => [
+            ['oneOf' => 'b'], // keep one valid field so we don't hit a parse-side issue
+            ['rs', 'ri', 'rf', 'rb', 'sized', 'atLeast10', 'lowerOnly'],
+        ];
+        // Empty string and null both count as "missing" per Binder
+        // contract — required fields fail.
+        yield 'required string is empty string' => [
+            ['rs' => ''] + $base,
+            ['rs'],
+        ];
+        yield 'required string is explicit null' => [
+            ['rs' => null] + $base,
+            ['rs'],
+        ];
+
+        // --- type cast failures ---
+        yield 'int field gets non-numeric' => [
+            ['ri' => 'banana'] + $base,
+            ['ri'],
+        ];
+        yield 'float field gets garbage' => [
+            ['rf' => 'banana'] + $base,
+            ['rf'],
+        ];
+
+        // --- attribute violations ---
+        yield 'sized too short' => [
+            ['sized' => 'a'] + $base,
+            ['sized'],
+        ];
+        yield 'sized too long' => [
+            ['sized' => 'abcdefg'] + $base,
+            ['sized'],
+        ];
+        yield 'atLeast10 below min' => [
+            ['atLeast10' => '3'] + $base,
+            ['atLeast10'],
+        ];
+        yield 'lowerOnly pattern fail' => [
+            ['lowerOnly' => 'ABC'] + $base,
+            ['lowerOnly'],
+        ];
+        yield 'oneOf not in set' => [
+            ['oneOf' => 'd'] + $base,
+            ['oneOf'],
+        ];
+
+        // --- multi-error collection ---
+        yield 'multiple violations all surface at once' => [
+            ['sized' => 'a', 'atLeast10' => '1', 'lowerOnly' => 'X'] + $base,
+            ['sized', 'atLeast10', 'lowerOnly'],
+        ];
+    }
+
+    /**
+     * @param array<string, mixed> $bag
+     * @param list<string>|null    $expectErrors
+     */
+    #[DataProvider('cases')]
+    public function testRuntimePath(array $bag, ?array $expectErrors): void
+    {
+        $this->runCase(
+            fn () => Binder::bind(BindMatrixDto::class, $bag),
+            $expectErrors,
+        );
+    }
+
+    /**
+     * @param array<string, mixed> $bag
+     * @param list<string>|null    $expectErrors
+     */
+    #[DataProvider('cases')]
+    public function testCompiledPath(array $bag, ?array $expectErrors): void
+    {
+        $compiled = Binder::compileFor(BindMatrixDto::class);
+        $this->runCase(fn () => $compiled($bag), $expectErrors);
+    }
+
+    /**
+     * @param callable(): BindMatrixDto $invoke
+     * @param list<string>|null         $expectErrors
+     */
+    private function runCase(callable $invoke, ?array $expectErrors): void
+    {
+        if ($expectErrors === null) {
+            $dto = $invoke();
+            $this->assertInstanceOf(BindMatrixDto::class, $dto);
+            // Spot-check the cast outcomes — the typed properties
+            // mean any incorrect cast would TypeError.
+            $this->assertSame(7, $dto->ri);
+            $this->assertSame(3.14, $dto->rf);
+            $this->assertTrue($dto->rb);
+            // Defaults survive when not in the bag.
+            $this->assertSame('fallback', $dto->os);
+            $this->assertNull($dto->ns);
+            return;
+        }
+
+        try {
+            $invoke();
+            $this->fail('expected ValidationException, got success');
+        } catch (ValidationException $e) {
+            $fields = array_column($e->errors(), 'field');
+            foreach ($expectErrors as $expected) {
+                $this->assertContains(
+                    $expected,
+                    $fields,
+                    "expected '$expected' in error fields, got " . implode(',', $fields),
+                );
+            }
+            $this->assertSame(422, $e->getCode());
+        }
+    }
+
+    public function testRuntimeAndCompiledProduceIdenticalErrorSets(): void
+    {
+        // For the same failing bag, the error fields must match
+        // between paths. The order doesn't matter, but the set must.
+        $bag = ['sized' => 'a', 'atLeast10' => '1', 'lowerOnly' => 'X'] + self::validBag();
+
+        $runtimeErrors = null;
+        try {
+            Binder::bind(BindMatrixDto::class, $bag);
+        } catch (ValidationException $e) {
+            $runtimeErrors = array_column($e->errors(), 'field');
+        }
+
+        $compiled = Binder::compileFor(BindMatrixDto::class);
+        $compiledErrors = null;
+        try {
+            $compiled($bag);
+        } catch (ValidationException $e) {
+            $compiledErrors = array_column($e->errors(), 'field');
+        }
+
+        sort($runtimeErrors);
+        sort($compiledErrors);
+        $this->assertSame($runtimeErrors, $compiledErrors);
+    }
+}

--- a/src/Rxn/Framework/Tests/Http/Binding/Fixture/BindMatrixDto.php
+++ b/src/Rxn/Framework/Tests/Http/Binding/Fixture/BindMatrixDto.php
@@ -1,0 +1,61 @@
+<?php declare(strict_types=1);
+
+namespace Rxn\Framework\Tests\Http\Binding\Fixture;
+
+use Rxn\Framework\Http\Attribute\InSet;
+use Rxn\Framework\Http\Attribute\Length;
+use Rxn\Framework\Http\Attribute\Min;
+use Rxn\Framework\Http\Attribute\Pattern;
+use Rxn\Framework\Http\Attribute\Required;
+use Rxn\Framework\Http\Binding\RequestDto;
+
+/**
+ * Lab DTO that exercises every cell of the
+ * (type × required × default × nullable) matrix the Binder claims
+ * to handle. Used by BinderMatrixTest to assert that every cell
+ * behaves identically under `bind()` and `compileFor()` — the two
+ * code paths must never diverge.
+ */
+final class BindMatrixDto implements RequestDto
+{
+    // --- required, no default, no null ---
+    #[Required]
+    public string $rs;
+
+    #[Required]
+    public int $ri;
+
+    #[Required]
+    public float $rf;
+
+    #[Required]
+    public bool $rb;
+
+    // --- optional with default ---
+    public string $os = 'fallback';
+    public int $oi = 42;
+    public float $of = 1.5;
+    public bool $ob = true;
+
+    // --- nullable, no default (falls back to null when missing) ---
+    public ?string $ns = null;
+    public ?int $ni = null;
+    public ?float $nf = null;
+
+    // --- attribute combos ---
+    #[Required]
+    #[Length(min: 2, max: 5)]
+    public string $sized;
+
+    #[Required]
+    #[Min(10)]
+    public int $atLeast10;
+
+    #[Required]
+    #[Pattern('/^[a-z]+$/')]
+    public string $lowerOnly;
+
+    #[Required]
+    #[InSet(['a', 'b', 'c'])]
+    public string $oneOf;
+}

--- a/src/Rxn/Framework/Tests/Http/Middleware/BearerAuthTest.php
+++ b/src/Rxn/Framework/Tests/Http/Middleware/BearerAuthTest.php
@@ -65,7 +65,14 @@ final class BearerAuthTest extends TestCase
             ->handle($this->bareRequest(), fn () => $this->okResponse());
 
         $this->assertSame(401, $response->getCode());
-        $this->assertSame('unauthorized', $response->meta['type']);
+        // Must be a real error response so App::render emits
+        // application/problem+json — anything less and the framework
+        // silently violates its RFC 7807 commitment for auth failures.
+        $this->assertTrue($response->isError());
+        $problem = $response->toProblemDetails('/test');
+        $this->assertSame(401, $problem['status']);
+        $this->assertSame('Unauthorized', $problem['title']);
+        $this->assertSame('Authentication required', $problem['detail']);
     }
 
     public function testMalformedHeaderReturns401(): void

--- a/src/Rxn/Framework/Tests/Http/OpenApi/GeneratorTest.php
+++ b/src/Rxn/Framework/Tests/Http/OpenApi/GeneratorTest.php
@@ -10,6 +10,62 @@ use Rxn\Framework\Tests\Http\OpenApi\Fixture\v2\OrderItemsController;
 
 final class GeneratorTest extends TestCase
 {
+    public function testGeneratedSpecMatchesPinnedShape(): void
+    {
+        // Snapshot the cross-controller spec so that any structural
+        // change to the OpenAPI generator becomes a deliberate diff
+        // — DTO attributes round-trip to JSON Schema (Min → minimum,
+        // Length → minLength/maxLength, InSet → enum) and the
+        // framework promises that mapping doesn't drift. The exact
+        // shape lives in Generator.php; this test is the spec-level
+        // contract.
+        $spec = (new Generator(
+            info: ['title' => 'Pinned', 'version' => '1.0.0'],
+            controllers: [
+                ProductsController::class,
+                WidgetsController::class,
+                OrderItemsController::class,
+            ],
+        ))->generate();
+
+        // Top-level shape.
+        $this->assertSame('3.0.3', $spec['openapi']);
+        $this->assertSame('Pinned', $spec['info']['title']);
+        $this->assertArrayHasKey('paths', $spec);
+        $this->assertArrayHasKey('components', $spec);
+
+        // Every action shows up at the convention path with the
+        // versioned operation id and a tag derived from controller.
+        $expectedPaths = [
+            '/v1.1/products/show',
+            '/v1.1/widgets/list',
+            '/v1.1/widgets/create',
+            '/v2.3/order_items/ship',
+        ];
+        foreach ($expectedPaths as $path) {
+            $this->assertArrayHasKey(
+                $path,
+                $spec['paths'],
+                "OpenAPI snapshot drift: missing path '$path'"
+            );
+        }
+
+        // The non-negotiable Problem Details schema is always present
+        // and carries the RFC 7807 fields. If any of these disappear,
+        // the framework's RFC compliance has silently regressed.
+        $pd = $spec['components']['schemas']['ProblemDetails']['properties'];
+        foreach (['type', 'title', 'status', 'detail', 'instance'] as $f) {
+            $this->assertArrayHasKey($f, $pd);
+        }
+
+        // Spec must be JSON-encodable (the bin/rxn openapi command
+        // emits this; it can never carry a non-encodable value).
+        $json = json_encode($spec, JSON_THROW_ON_ERROR);
+        $this->assertIsString($json);
+        $decoded = json_decode($json, true, 512, JSON_THROW_ON_ERROR);
+        $this->assertSame($spec, $decoded);
+    }
+
     public function testGenerateProducesBasicEnvelope(): void
     {
         $spec = (new Generator(

--- a/src/Rxn/Framework/Tests/Http/RouterTest.php
+++ b/src/Rxn/Framework/Tests/Http/RouterTest.php
@@ -316,6 +316,98 @@ final class RouterTest extends TestCase
         $this->assertNotNull($r->match('GET', '/anything/whatever-123'));
     }
 
+    /**
+     * Adversarial inputs for the route compiler. Each pattern is
+     * something a fuzz test or hostile input could land on. We
+     * assert that compile + match either succeeds (the pattern is
+     * legitimately accepted) or throws a clean
+     * InvalidArgumentException — never a PHP warning, never a
+     * RuntimeException, never an "unintended match."
+     */
+    public static function adversarialPatterns(): iterable
+    {
+        // Format: [pattern, valid_url_to_match_or_null, invalid_url, throws_on_register]
+        yield 'placeholder name has digit prefix'          => ['/{1bad:int}', null, null, true];
+        yield 'placeholder name has hyphen'                => ['/{na-me:int}', null, null, true];
+        yield 'placeholder type unknown'                   => ['/{x:never_heard_of_it}', null, null, true];
+        yield 'literal regex chars in segment are quoted'  => ['/foo.bar/{id:int}', '/foo.bar/42', '/foo_bar/42', false];
+        yield 'literal regex anchor in segment quoted'     => ['/^weird$/{id:int}', '/^weird$/7', '/zweirdz/7', false];
+        yield 'two placeholders in adjacent segments'      => ['/u/{a:int}/p/{b:slug}', '/u/1/p/x-y', '/u/abc/p/x', false];
+        yield 'uuid constraint rejects shortened uuid'     => ['/s/{id:uuid}', '/s/550e8400-e29b-41d4-a716-446655440000', '/s/550e8400-e29b-41d4-a716-44665544000', false];
+        yield 'multi-segment value rejected by single-seg' => ['/u/{id:int}', '/u/42', '/u/42/extra', false];
+        yield 'empty placeholder name'                     => ['/u/{:int}', null, null, true];
+    }
+
+    /** @dataProvider adversarialPatterns */
+    public function testRouteCompilerHandlesAdversarialPatterns(
+        string $pattern,
+        ?string $shouldMatch,
+        ?string $shouldNotMatch,
+        bool $throwsOnRegister,
+    ): void {
+        $r = new Router();
+        if ($throwsOnRegister) {
+            $this->expectException(\InvalidArgumentException::class);
+            $r->get($pattern, 'h');
+            return;
+        }
+        $r->get($pattern, 'h');
+        if ($shouldMatch !== null) {
+            $this->assertNotNull(
+                $r->match('GET', $shouldMatch),
+                "expected '$pattern' to match '$shouldMatch'"
+            );
+        }
+        if ($shouldNotMatch !== null) {
+            $this->assertNull(
+                $r->match('GET', $shouldNotMatch),
+                "expected '$pattern' to NOT match '$shouldNotMatch'"
+            );
+        }
+    }
+
+    public function testTrailingSlashIsNormalised(): void
+    {
+        $r = new Router();
+        $r->get('/products/{id:int}', 'h');
+        $this->assertNotNull($r->match('GET', '/products/42'));
+        $this->assertNotNull($r->match('GET', '/products/42/'));
+    }
+
+    public function testQueryStringIsStrippedBeforeMatch(): void
+    {
+        $r = new Router();
+        $r->get('/products/{id:int}', 'h');
+        // parse_url should drop ?foo=bar before regex matching.
+        $this->assertNotNull($r->match('GET', '/products/42?foo=bar'));
+    }
+
+    public function testStaticHashmapDoesNotShadowEarlierPlaceholderRoute(): void
+    {
+        // Registration order: placeholder first, static second. The
+        // placeholder must still win (it would have under the old
+        // linear walk).
+        $r = new Router();
+        $r->get('/items/{id}', 'placeholder');
+        $r->get('/items/special', 'static');
+
+        $hit = $r->match('GET', '/items/special');
+        $this->assertNotNull($hit);
+        $this->assertSame('placeholder', $hit['handler']);
+    }
+
+    public function testStaticHashmapServesStaticWhenNoShadow(): void
+    {
+        $r = new Router();
+        $r->get('/items/special', 'static');
+        $r->get('/items/{id:int}', 'by-id');
+
+        $a = $r->match('GET', '/items/special');
+        $b = $r->match('GET', '/items/42');
+        $this->assertSame('static', $a['handler']);
+        $this->assertSame('by-id', $b['handler']);
+    }
+
     private function passthrough(): Middleware
     {
         return new class implements Middleware {


### PR DESCRIPTION
## Summary

Three commits backported from the `experiment/psr-7-refactor` branch that stand on their own as fixes/improvements to master.

### `fix(PsrAdapter): wrap php://input as default body stream`

Real bug. `PsrAdapter::serverRequestFromGlobals()` passed `null` as the body to Nyholm's `ServerRequest`, which causes `MessageTrait::getBody()` to initialise the stream to an empty in-memory string on first read. Anything reading a request body through PSR-7 — the existing `Psr15Pipeline` escape hatch, any drop-in PSR-15 middleware — silently saw zero bytes for POST / PUT / PATCH requests.

Fix mirrors what Nyholm's own `ServerRequestCreator::fromGlobals()` does: `fopen('php://input', 'r')` passed as the body. The fopen is a cheap descriptor allocation; the read cost lives in `getBody()->getContents()` and is paid only when something asks.

Surfaced while building a PSR-7 end-to-end bench app on the experiment branch — every POST returned a spurious 422 because the binder saw an empty body.

### `fix(bench/compare): reuse curl handles instead of close-and-recreate per request`

`Load::run()` was calling `curl_close($h)` on each completed handle and `curl_init()` for the refill, destroying curl's connection cache and forcing a fresh TCP socket per request. At ~17k rps × concurrency=10 that's ~17,000 new ephemeral ports per second; the pool (~28k ports, 60s TIME_WAIT) saturates within seconds and produces the per-route Latin-square outlier pattern that's been making A/B verdicts on this harness unreliable.

Reusing the same `CurlHandle` across remove/re-add cycles preserves curl's internal connection cache. Median throughput climbs +5% (rxn) under `php -S` even though the server itself emits `Connection: close` — the small fraction of requests where curl re-arms before the kernel observes FIN now reuse. Under any keep-alive server (FrankenPHP / RoadRunner / PHP-FPM) the fix is fully effective and pins open-socket count at ~`concurrency` for the whole run.

### `feat(bench/compare): report median-window rps alongside count/duration rps`

The actual fix for the Latin-square noise. `count/duration` rps is sensitive to brief stalls — a 1-second worker handoff in a 7-second window costs 14% of the headline number even though the other 6 seconds were running at full speed. The fix bins every completion's end timestamp into 100ms windows, drops the partially-populated first and last bins, and takes the median of the remaining bin counts scaled to req/sec. The result is "the rate a typical 100ms slice of the run saw" — robust to brief bursts and exactly what every framework-comparison verdict cares about.

Empirical validation on a known-stalled cell:

```
rxn POST 422 (stalled)  raw 10,436 rps   window 16,970 rps   p50 0.58 ms
rxn POST valid (clean)  raw 17,054 rps   window 17,270 rps   p50 0.57 ms
```

Stalled vs clean: 39% apart on raw rps, 2% apart on median-window — matching the p50 latency story. Both metrics are reported in CLI output and the markdown table; A/B verdicts should be read off `rps_median_window`.

## Test plan

- [x] `vendor/bin/phpunit` — 431 tests, 960 assertions, all green
- [x] `php bench/compare/run.php --frameworks=rxn --duration=2` — runs cleanly, shows new metric: `17,704 rps (median-window 17,650) (p50 0.55 ms / p99 0.89 ms)`
- [x] PSR-7 path POST body smoke test — `curl -X POST -H 'Content-Type: application/json' -d '{"name":"X","price":1}' ...` returns 201 with hydrated DTO (was returning 422 before the PsrAdapter fix)
- [ ] Re-run the cross-framework `bench/compare` matrix at higher N to refresh the published numbers (separate task)

## Cross-link

These backports come from the experiment branch's harness diagnosis — see `bench/ab/experiments/2026-05-01-bench-compare-harness-fix.md` on `experiment/psr-7-refactor` for the full investigation.