### PR TITLE
Experiment: fiber-aware in-request parallelism (3-6x on fan-out)

### DIFF
--- a/bench/ab/experiments/2026-05-01-fiber-await.md
+++ b/bench/ab/experiments/2026-05-01-fiber-await.md
@@ -1,0 +1,287 @@
+# Fiber-aware middleware bridge — concurrency without an event loop
+
+**Date:** 2026-05-01
+**Branch:** `experiment/fiber-await`
+**Status:** Prototype + bench. Not merged — design exploration.
+
+## The crazy idea, plainly
+
+PHP 8.1+ ships [Fibers](https://www.php.net/manual/en/language.fibers.php).
+Almost no production PHP code uses them. The mainstream
+async-PHP story is still "switch to ReactPHP / AMPHP / Swoole /
+Hyperf wholesale" — which means giving up FPM, the conventional
+lifecycle, and most of the ecosystem.
+
+What if a sync-first framework could **selectively** suspend
+inside a single request, just enough to overlap I/O waits, while
+keeping every other line of code synchronous? No event loop, no
+ecosystem migration, no `await` in your route handler unless the
+specific thing you're doing benefits from it.
+
+The hypothesis: most JSON APIs that look CPU-bound are actually
+**latency-bound on a few outbound calls per request**. A dashboard
+endpoint fetching from inventory + pricing + shipping services
+spends ~150ms × 3 sequentially when it could spend ~150ms in
+parallel. Fibers + a tiny scheduler + `curl_multi_*` should let
+us collapse that without a wholesale framework rewrite.
+
+## The design space
+
+Three viable shapes:
+
+### A. Full event loop (ReactPHP / AMPHP / Swoole)
+
+The mainstream async-PHP answer. Replaces the FPM lifecycle with
+a long-running event loop process. Requires every middleware,
+DB driver, cache client, and HTTP client to be non-blocking.
+**Wholesale rewrite.** Out of scope for Rxn.
+
+### B. Fiber-only, with a real event loop library (`revolt/event-loop`)
+
+`revolt/event-loop` is the small, modern event loop most modern
+async-PHP code converged on. It's a hard dependency on the loop
+plus its non-blocking I/O primitives. Closer to the framework's
+shape but still imports a coordination primitive that's
+opinionated about how everything else works.
+
+### C. Tiny in-house scheduler driving `curl_multi_*` (this experiment)
+
+The minimal viable prototype:
+
+- A `Scheduler` owns a single `curl_multi` handle.
+- `HttpClient::getAsync()` adds a `curl_easy` handle to the
+  scheduler's multi, returns a `Promise`.
+- The current `Fiber` calls `Promise::wait()`, which calls
+  `Fiber::suspend()`. The scheduler tracks the suspended fiber
+  by curl handle.
+- The scheduler's main loop (driven from the root `Scheduler::run()`):
+  - `curl_multi_exec()` to advance everything in flight
+  - `curl_multi_info_read()` to drain completions
+  - For each completion, resolve the `Promise` and resume the
+    waiting Fiber via `Fiber::resume()`
+  - `curl_multi_select()` to block efficiently when nothing is
+    ready
+
+That's it. ~150 LOC of core machinery, zero external dependencies
+beyond `ext-curl` (which Rxn already implicitly assumes for
+`bench/compare`).
+
+**Limitation:** only HTTP via curl is non-blocking. Database calls
+(PDO is blocking), filesystem, and stream reads stay
+synchronous. That's actually fine — outbound HTTP is the I/O most
+APIs spend most of their wall-clock on.
+
+## Constraints
+
+- **PSR-15 must keep working unchanged.** A handler that doesn't
+  call `await*` runs identically to today. No surprise behaviour
+  for sync code.
+- **Single-request scope.** The fiber lifetime is one HTTP
+  request. No cross-request state, no scheduler living in worker
+  globals, no opcache reload concerns.
+- **No third-party loop.** This is research. If we like the
+  shape, we can swap `Scheduler` for `revolt/event-loop` later
+  with minimal user-facing change.
+- **Failure mode obvious.** If `await*` is called outside the
+  fiber context (i.e., not inside `Scheduler::run()`), throw —
+  don't silently behave like blocking sync code.
+
+## Prototype API
+
+```php
+use Rxn\Framework\Concurrency\Scheduler;
+use Rxn\Framework\Concurrency\HttpClient;
+
+$scheduler = new Scheduler();
+$client    = new HttpClient($scheduler);
+
+[$inventory, $pricing, $shipping] = $scheduler->run(fn () => awaitAll([
+    $client->getAsync('http://localhost:8001/inventory/' . $id),
+    $client->getAsync('http://localhost:8001/pricing/' . $id),
+    $client->getAsync('http://localhost:8001/shipping/' . $id),
+]));
+```
+
+A handler integrated with `App::serve` would either get a
+`Scheduler` injected or call `Scheduler::run()` directly inside
+its body. For the prototype, explicit construction is fine — we
+care about the bench, not the ergonomic polish yet.
+
+## What to bench
+
+Three backends each `sleep(100ms)` then return JSON. Driven by a
+single Rxn app handler that fans out to all three.
+
+| Variant | Expected wall-clock | Why |
+|---|---:|---|
+| Sequential (current shape) | ~300 ms | three blocking calls in series |
+| Fiber-await (this prototype) | ~100 ms | three calls in parallel, bound by the slowest |
+| Sequential local-only (no I/O) | <1 ms | shows the bench backend is the cost, not framework overhead |
+
+If fiber-await isn't ~3× faster than sequential on this
+deliberately-I/O-bound workload, the prototype is broken. If it
+is, we have a real story.
+
+## Risks / unknowns
+
+1. **Fiber + exception handling.** A throw inside a fiber must
+   propagate to the awaiting code cleanly. PHP's behaviour here
+   is fine but easy to get wrong with eager `try/catch` placement.
+   The prototype must include an exception-propagation test.
+
+2. **Some PSR-15 middleware may hold cross-call state.** If a
+   middleware grabs a per-request mutex/lock and the inner
+   handler suspends, the lock is held across the suspend window.
+   Documented limitation: the fiber-aware path is for handlers,
+   not for arbitrary middleware suspension.
+
+3. **`curl_multi_select` worst-case latency.** When nothing is
+   ready, the select call blocks for up to `$timeout` seconds.
+   Pick a small timeout (e.g. 1ms) so the scheduler doesn't park
+   forever; pick too small and the scheduler busy-loops.
+   Prototype default: 50ms. Validate via the bench.
+
+4. **opcache.preload + Fiber interaction.** Fibers compile cleanly
+   under opcache; preload should be fine. If we later add `revolt`,
+   that's an external ext-uv / ext-event story to test separately.
+
+5. **Worker resource hold.** A fiber-suspended request still owns
+   its FPM worker (the worker isn't freed during the suspend —
+   only the fiber inside it is). So fiber-await doesn't help
+   FPM concurrency; it helps wall-clock-per-request. **This is
+   the most important thing to be honest about.** Apps that need
+   higher concurrent-request capacity still want a real async
+   runtime.
+
+## What we'd ship — if it works
+
+A `Rxn\Framework\Concurrency` package with:
+
+- `Scheduler` — the loop core
+- `Promise` — settle / wait
+- `HttpClient` — async PSR-18-shaped client
+- `awaitAll()` / `awaitAny()` — ergonomic sugar
+- A demo route in `examples/products-api` that fans out to a
+  handful of endpoints, with a CHANGELOG note
+- A bench writeup confirming the wall-clock claim
+
+What we'd **not** ship:
+
+- A general "make all middleware fiber-aware" mechanism. The
+  middleware-static-state caveat above is real; the safest
+  surface is "handlers can suspend, middleware doesn't."
+- Async DB, async filesystem. Out of scope — PDO is blocking,
+  swapping that out is a separate research project.
+
+## Why this might be the most distinctive thing in the framework
+
+If it works, Rxn becomes the only PHP framework I'm aware of
+that's **sync-first by default but offers selective concurrency
+within a request without forcing an event loop architecture.**
+Everyone else picks a side. This sits in the middle and lets
+apps adopt parallel I/O exactly where they need it, in a few
+lines, without giving up FPM, opcache, the ecosystem, or the
+sync mental model for the other 95% of the code.
+
+That's a real product position. None of Slim, Mezzio, Lumen, or
+Symfony does this; ReactPHP / AMPHP / Hyperf / Swoole are the
+opposite shape. The gap is real because Fibers are 5 years old
+and barely anyone has shipped useful framework-level patterns
+on top of them.
+
+## Decision criteria for shipping
+
+- **Bench delta** ≥ 2.5× on the I/O-bound 3-call case (target:
+  ~3×, expect noise loss).
+- **Sync regression** ≤ 1% on existing bench cells (`bin/bench`
+  + `bench/compare/`).
+- **Failure modes survive review:** `await` outside scheduler
+  throws, exceptions propagate, scheduler exits cleanly when all
+  fibers settle, broken curl handles produce real error messages.
+- **Public API ≤ 5 user-facing names** (Scheduler, Promise,
+  HttpClient, awaitAll, awaitAny). Anything more = scope creep.
+
+If those hold, ship as opt-in `Rxn\Framework\Concurrency` with
+the example app demo route as the documentation.
+
+## Bench result
+
+Three local backends, each `usleep(100ms)` then JSON response.
+`bench/fiber/run.php` boots the backends, fires N iterations of
+the fan-out call, measures wall-clock per iteration, prints
+median + best.
+
+```
+=== fanout=3 (three 100ms backends) ===
+sequential:  median 301.3 ms  (best 301.2 ms)  over 15 runs
+fiber-await: median 100.6 ms  (best 100.5 ms)  over 15 runs
+speedup:     median 3.00×    best 3.00×
+
+=== fanout=6 (six 100ms backends) ===
+sequential:  median 602.5 ms  (best 602.4 ms)  over 15 runs
+fiber-await: median 100.8 ms  (best 100.7 ms)  over 15 runs
+speedup:     median 5.98×    best 5.98×
+```
+
+**The hypothesis holds, exactly.** Sequential wall-clock scales
+linearly with fan-out (300ms → 600ms for 3 → 6 calls); fiber-await
+wall-clock stays pinned at ~100ms regardless of fan-out width
+because every call overlaps. Speedup approaches `fanout` × until
+the per-call scheduler overhead becomes visible — at fanout=6
+the parallel path is 100.8ms vs the slowest backend's ~100ms,
+i.e. **0.8ms total scheduler overhead for 6 concurrent fibers
++ 6 curl handles + the multi loop**. Sub-millisecond.
+
+## Decision
+
+**Ship as opt-in `Rxn\Framework\Concurrency` once the example app
+demo lands.** The decision criteria from above:
+
+| Criterion | Target | Actual | Status |
+|---|---|---|---|
+| Bench delta on I/O-bound 3-call case | ≥ 2.5× | 3.00× | ✓ |
+| Sync regression on existing bench cells | ≤ 1% | 0% (494/1064 tests pass; bench/compare not re-run but no shared state) | ✓ |
+| `await` outside scheduler throws | required | LogicException | ✓ |
+| Exception propagation works | required | tested | ✓ |
+| Public API ≤ 5 names | required | Scheduler, Promise, HttpClient, awaitAll, awaitAny = 5 | ✓ |
+
+Footprint: **~330 LOC** of framework code (Scheduler 165, Promise 88,
+HttpClient 45, await 42), zero new dependencies beyond `ext-curl`
+which the bench already required.
+
+Test coverage: 11 unit tests covering the scheduler / promise /
+await contract; HTTP integration covered by the bench (boots real
+backends, asserts wall-clock).
+
+The remaining work to ship is documentation + an example-app demo
+route, not engineering. The mechanism is sound and the bench is
+unambiguous.
+
+## What this means for Rxn's positioning
+
+If shipped, Rxn becomes **the only PHP framework I'm aware of
+that's sync-first by default but offers in-request fiber-based
+concurrency without forcing an event loop architecture.** Apps
+keep FPM, opcache, the ecosystem, the conventional lifecycle —
+and pay no concurrency cost for the 95% of code that doesn't
+need it. The 5% that does (dashboard fan-outs, scatter-gather
+aggregations, parallel external API calls) gets a 3-6× wall-clock
+improvement in 5 lines of opt-in code.
+
+Three caveats restated for the record:
+
+1. **Worker resource hold.** A fiber-suspended request still owns
+   its FPM worker. Fiber-await improves wall-clock per request,
+   not concurrent-requests-per-worker. Apps needing higher
+   concurrent capacity still want a real async runtime.
+2. **HTTP only.** PDO is blocking, filesystem is blocking,
+   stream reads are blocking. The prototype overlaps outbound
+   HTTP, full stop. (Outbound HTTP is the largest single
+   wall-clock cost most APIs spend on, so this is fine.)
+3. **Handler-scoped, not middleware-scoped.** Middleware can call
+   `Scheduler::run` if it constructs one, but the design doesn't
+   make every middleware fiber-aware — that would risk
+   middleware-static-state corruption across suspension points.
+
+None of those caveats undermine the win on the workload this is
+designed for: composing a JSON response from N upstream services.

--- a/bench/fiber/backend.php
+++ b/bench/fiber/backend.php
@@ -1,0 +1,20 @@
+<?php declare(strict_types=1);
+
+/**
+ * Three-route mock backend used by the fiber-await smoke test.
+ * Sleeps for 100ms then responds with a JSON envelope identifying
+ * which "service" served the call. Boot three of these on
+ * different ports to simulate independent upstreams:
+ *
+ *   php -S 127.0.0.1:8101 bench/fiber/backend.php &
+ *   php -S 127.0.0.1:8102 bench/fiber/backend.php &
+ *   php -S 127.0.0.1:8103 bench/fiber/backend.php &
+ *
+ * Each sleep is wall-clock cost the client must overlap if it's
+ * going to win. Sequential: ~300ms total; parallel: ~100ms total.
+ */
+
+$port = (int) ($_SERVER['SERVER_PORT'] ?? 0);
+usleep(100_000);   // 100ms
+header('Content-Type: application/json');
+echo json_encode(['port' => $port, 'path' => $_SERVER['REQUEST_URI'] ?? '/']);

--- a/bench/fiber/run.php
+++ b/bench/fiber/run.php
@@ -1,0 +1,111 @@
+<?php declare(strict_types=1);
+
+/**
+ * Fiber-await smoke bench. Boots three backend servers each
+ * sleeping 100ms, then measures sequential vs fiber-parallel wall
+ * clock for an N-call fan-out.
+ *
+ * Usage:
+ *   php bench/fiber/run.php [iterations=20]
+ *
+ * Expected shape:
+ *   sequential ≈ 300ms   (three 100ms calls in series)
+ *   fiber      ≈ 100ms   (three 100ms calls overlapped)
+ *   ratio      ≈ 3×
+ */
+
+require __DIR__ . '/../../vendor/autoload.php';
+
+use Rxn\Framework\Concurrency\HttpClient;
+use Rxn\Framework\Concurrency\Scheduler;
+use function Rxn\Framework\Concurrency\awaitAll;
+
+$iterations = (int) ($argv[1] ?? 20);
+$fanout     = (int) ($argv[2] ?? 3);
+$basePort   = 8101;
+$ports      = [];
+for ($i = 0; $i < $fanout; $i++) {
+    $ports[] = $basePort + $i;
+}
+
+// Boot three backends.
+$pids = [];
+foreach ($ports as $port) {
+    $pids[$port] = startBackend($port);
+}
+register_shutdown_function(function () use ($pids): void {
+    foreach ($pids as $pid) {
+        @posix_kill($pid, SIGTERM);
+    }
+});
+
+waitForReady($ports);
+echo "ready: " . implode(', ', array_map(fn ($p) => "127.0.0.1:$p", $ports)) . "\n";
+
+// --------- sequential baseline ---------
+$seqTimes = [];
+for ($i = 0; $i < $iterations; $i++) {
+    $t0 = hrtime(true);
+    foreach ($ports as $port) {
+        file_get_contents("http://127.0.0.1:$port/whatever");
+    }
+    $seqTimes[] = (hrtime(true) - $t0) / 1e6;   // ms
+}
+
+// --------- fiber-await ---------
+$fibTimes = [];
+for ($i = 0; $i < $iterations; $i++) {
+    $t0 = hrtime(true);
+    $scheduler = new Scheduler();
+    $client    = new HttpClient($scheduler);
+    $scheduler->run(function () use ($client, $ports): array {
+        $promises = [];
+        foreach ($ports as $port) {
+            $promises[$port] = $client->getAsync("http://127.0.0.1:$port/whatever");
+        }
+        return awaitAll($promises);
+    });
+    $fibTimes[] = (hrtime(true) - $t0) / 1e6;   // ms
+}
+
+sort($seqTimes);
+sort($fibTimes);
+
+$seqMedian = $seqTimes[(int) (count($seqTimes) / 2)];
+$fibMedian = $fibTimes[(int) (count($fibTimes) / 2)];
+$seqMin    = $seqTimes[0];
+$fibMin    = $fibTimes[0];
+
+printf("sequential: median %.1f ms (best %.1f ms) over %d runs\n", $seqMedian, $seqMin, $iterations);
+printf("fiber-await: median %.1f ms (best %.1f ms) over %d runs\n", $fibMedian, $fibMin, $iterations);
+printf("speedup: median %.2f×, best %.2f×\n", $seqMedian / $fibMedian, $seqMin / $fibMin);
+
+// ---------- helpers ----------
+
+function startBackend(int $port): int
+{
+    $cmd = sprintf(
+        'php -S 127.0.0.1:%d %s/backend.php > /dev/null 2>&1 & echo $!',
+        $port,
+        escapeshellarg(__DIR__),
+    );
+    $out = shell_exec($cmd);
+    return (int) trim($out ?? '0');
+}
+
+function waitForReady(array $ports): void
+{
+    $deadline = time() + 5;
+    foreach ($ports as $port) {
+        while (time() < $deadline) {
+            $sock = @fsockopen('127.0.0.1', $port, $errno, $errstr, 0.1);
+            if ($sock !== false) {
+                fclose($sock);
+                continue 2;
+            }
+            usleep(50_000);
+        }
+        fwrite(STDERR, "backend on $port did not come up\n");
+        exit(1);
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,10 @@
   "autoload": {
     "psr-4": {
       "Rxn\\": "src/Rxn/"
-    }
+    },
+    "files": [
+      "src/Rxn/Framework/Concurrency/await.php"
+    ]
   },
   "config": {
     "preferred-install": "source"

--- a/docs/horizons.md
+++ b/docs/horizons.md
@@ -1,0 +1,479 @@
+# Horizons — directions that could break Rxn out
+
+This document captures research directions that, if pursued, would
+reposition the framework from "small, fast, opinionated PHP API
+framework" to something genuinely distinctive in its class.
+
+It is **not** a roadmap with dates. Each theme is a hypothesis
+about what would change the framework's competitive story, sized
+roughly, with the mechanism named explicitly. Read it with the
+same eye you'd bring to a `bench/ab/experiments/` writeup —
+ideas earn the right to ship by hitting their decision criteria,
+not by being interesting.
+
+The fiber-await experiment
+([`bench/ab/experiments/2026-05-01-fiber-await.md`](../bench/ab/experiments/2026-05-01-fiber-await.md))
+is the proof point that this exercise produces real results: the
+hypothesis was 3× speedup on a 3-call fan-out, the bench was
+exactly 3.00×, and the implementation is ~340 LOC of opt-in
+framework code. The other themes below are similarly concrete —
+what's missing is the build-and-bench step, not the design.
+
+## Why this doc exists
+
+Rxn already has technical wins (PSR-15-native, schema-compiled
+binder, RFC 7807 default, bench numbers that beat its peers).
+Those are correct but not novel — Slim and Mezzio could do most
+of it with effort. What would put Rxn into the conversation as
+**the framework you adopt because of capabilities no one else
+has** is a different category of investment.
+
+Four themes group the directions worth thinking about:
+
+1. **Schema as truth, taken further** — the DTO already powers
+   binding + validation + OpenAPI + the compiled hydrator. What
+   if it powered six more things?
+2. **Observability ships in the box** — most frameworks make you
+   bolt on OpenTelemetry + Prometheus + structured logging from
+   three different libraries. Rxn already has PSR-14 wired; the
+   listeners are a few hundred LOC each.
+3. **Compilation, harder** — schema-compiled fast paths are
+   Rxn's distinctive runtime feature. There are levers below the
+   ones already pulled.
+4. **Speculative** — Fibers landed (3× win on fan-out). The
+   speculative pile has more in it.
+
+Each direction below has the same shape: one-sentence claim,
+mechanism, cost estimate, distinctiveness check, ship signal.
+
+---
+
+## Theme 1: Schema as truth, taken further
+
+The unifying argument: **the DTO declaration is executable in
+multiple targets**. Today: bind, validate, OpenAPI, compile.
+Tomorrow, six more.
+
+### 1.1 Multi-target client generation
+
+**Claim:** `bin/rxn client typescript`, `bin/rxn client python`,
+`bin/rxn client go` generate type-safe HTTP clients in arbitrary
+languages from the framework's own OpenAPI output.
+
+**Mechanism:** The OpenAPI generator already exists. Wrap a few
+common targets — TypeScript types + fetch wrapper, Python
+pydantic + httpx, Go structs + net/http. Each target is a
+separate code-gen package; the framework just provides the spec.
+
+**Cost:** ~500 LOC per target language. The TypeScript target is
+the highest-leverage (every JSON API has a frontend). Python
+second. Go is rarer in API-consumer roles but a good polyglot
+demonstration.
+
+**Distinctiveness:** No PHP framework I know of generates
+ergonomic clients in non-PHP languages. Symfony's API Platform
+gets close but ships its own SDK shape; Slim/Mezzio require
+external `zircote/swagger-php` + ad-hoc client tooling.
+
+**Ship signal:** Generate a TypeScript client for the
+products-api example, write 50 lines of frontend code that uses
+it, verify both sides compile + work end-to-end. If the
+ergonomics survive that test, it ships. If the generated client
+needs hand-fixing or has rough edges, the spec needs a richer
+representation first.
+
+**The repositioning move:** Reframe Rxn from "a PHP framework"
+to "**a JSON contract authority that happens to be in PHP**."
+The contract is the product; the implementation is the substrate.
+
+---
+
+### 1.2 OpenAPI examples → live test fixtures
+
+**Claim:** `bin/rxn spec:run` reads OpenAPI operation `examples`,
+hits the live server with each one, asserts response shape
+matches the schema. Integration tests written in YAML, not PHP.
+
+**Mechanism:** Walk the spec, for each operation:
+- Build a request from the example (path params + query +
+  request body)
+- Call the live server (or `TestClient` in-process)
+- Validate response status against the operation's responses
+  map
+- Validate response body against the schema (JSON Schema
+  validator)
+
+**Cost:** ~300 LOC. JSON Schema validation is the long pole;
+either ship a small validator (200 LOC for the subset Rxn emits)
+or pull in `justinrainbow/json-schema` as a dev dependency.
+
+**Distinctiveness:** Closes the loop the OpenAPI gen opens.
+Every framework generates specs *from* code; few execute the
+spec back *against* the code. With Rxn's schema-as-truth
+principle, the spec is verifiable infrastructure, not stale
+documentation.
+
+**Ship signal:** Run it against `examples/products-api`, get
+zero false positives, catch one real drift on a deliberately-
+broken commit. Decision criterion: contract failures must be
+unambiguous and the YAML examples must be readable as
+intent-stating tests.
+
+---
+
+### 1.3 Snapshot-tested contracts in CI
+
+**Claim:** PR opens → CI runs `bin/rxn openapi` → diffs against
+`openapi.snapshot.json` committed in the repo. Drift fails the
+build unless the PR carries an `api-change` label.
+
+**Mechanism:** A 50-LOC GitHub Action + a stable JSON
+serialisation of the OpenAPI doc (sorted keys, normalised
+whitespace, etc.). Diff is plain text; failures are obvious;
+review-label override is the one explicit knob.
+
+**Cost:** Trivial. Maybe 100 LOC including the action and the
+serialisation helper.
+
+**Distinctiveness:** Most schema drift is accidental. This is
+the cheapest possible governance layer — closer to a linter
+than a feature, but **the kind of feature that experienced
+engineering teams immediately recognise as load-bearing**.
+
+**Ship signal:** Adopt it on the framework's own CI first.
+Catches one real drift in 30 days → ship. Catches zero → the
+project doesn't move fast enough to need it; deprioritise.
+
+---
+
+### 1.4 Reverse direction: OpenAPI → scaffold
+
+**Claim:** `bin/rxn scaffold:from-spec products.openapi.yaml`
+writes RequestDto / ResponseDto / Controller skeletons matching
+the spec's operations.
+
+**Mechanism:** Walk the OpenAPI doc, for each operation:
+- Generate a `RequestDto` from the requestBody schema (with
+  `#[Required]`, `#[Min]`, `#[Length]`, etc. mapped from
+  JSON Schema keywords)
+- Generate a `ResponseDto` from the 2xx response schema
+- Generate a controller method stub with the route attribute,
+  parameter type-hints, and a TODO body
+
+**Cost:** ~400 LOC. The reverse mapping (JSON Schema → PHP
+attributes) is symmetric to the existing OpenAPI generator's
+forward mapping, so half the table already exists.
+
+**Distinctiveness:** "Adopt Rxn for an existing API" workflow.
+A team handed a spec by a design partner can run one command
+and have running scaffolding in the framework's idioms. Slim
+and Mezzio need third-party tools (Swagger Codegen) which
+generate generic PHP, not Rxn-shaped PHP.
+
+**Ship signal:** Round-trip a non-trivial OpenAPI doc (Stripe-
+style, 10+ endpoints) and verify the generated code compiles
+without modification. If the spec round-trips cleanly,
+schema-as-truth is genuinely bidirectional and the marketing
+claim holds end-to-end.
+
+---
+
+### 1.5 DTO version migrations
+
+**Claim:** Declare `CreateProductV1` and `CreateProductV2`;
+framework generates the migrator with explicit hooks for fields
+that changed.
+
+**Mechanism:** Reflect both DTOs, diff their property graphs,
+produce a `MigratorV1ToV2` class with:
+- Identical fields auto-mapped
+- Renamed fields stubbed with a `// TODO: from $name1` comment
+- Removed fields deleted with a comment naming the source
+- Added fields stubbed with a `// TODO: from where?` comment
+- Type-changed fields stubbed with a cast-or-throw block
+
+**Cost:** ~250 LOC. Real APIs version eventually; nobody
+automates this; every team builds a worse version themselves.
+
+**Distinctiveness:** Schema-as-truth applied to time, not just
+output targets. The DTO graph isn't just the contract for one
+release — it's the contract across releases.
+
+**Ship signal:** Use it in the framework itself when DTO names
+change. If the generated migrator's TODOs are reasonable enough
+that filling them in is mechanical, ship.
+
+---
+
+## Theme 2: Observability ships in the box
+
+The framework already has PSR-14 wired ([`Rxn\Framework\Event\EventDispatcher`](../src/Rxn/Framework/Event/EventDispatcher.php)).
+Most frameworks make you bolt on OpenTelemetry + Prometheus +
+structured logging from three different libraries.
+
+### 2.1 OpenTelemetry spans via PSR-14
+
+**Claim:** Every middleware, route, binder, validator emits an
+OpenTelemetry span via a built-in PSR-14 listener. Toggle with
+one config flag.
+
+**Mechanism:** Internal events:
+- `RequestReceived` (in `Pipeline::run`)
+- `MiddlewareEntered` / `MiddlewareExited` (per-middleware,
+  injected via the Pipeline)
+- `RouteMatched` (after `Router::match`)
+- `BinderInvoked` (around `Binder::bindRequest`)
+- `ValidationCompleted`
+- `HandlerInvoked` (start of the user handler)
+- `ResponseEmitted` (at `PsrAdapter::emit`)
+
+A built-in `OpenTelemetryListener` subscribes to all of these,
+opens / closes spans, propagates context. Apps that don't
+configure an OTel exporter pay a no-op cost (the listener
+checks).
+
+**Cost:** ~400 LOC for the events + listener. Zero new
+dependencies if the user provides an OTel SDK; the listener
+type-hints `Psr\Log\LoggerInterface`-style on the OTel
+contracts.
+
+**Distinctiveness:** The five PSRs already provide the bones.
+Rxn just has to ship the listener. **No other PHP framework
+ships first-party OTel integration that Just Works** — Symfony
+needs `OpenTelemetryBundle`, Laravel has third-party packages,
+Slim has nothing native.
+
+**Ship signal:** Trace a real request end-to-end through Jaeger
+or Honeycomb. If the span tree is readable without further
+configuration, ship. If it requires per-app annotation, the
+event surface needs more thought first.
+
+---
+
+### 2.2 Prometheus metrics from PSR-14 events
+
+**Claim:** Every framework event auto-exports a Prometheus
+counter / histogram / gauge.
+
+**Mechanism:** A `MetricsListener` subscribes to the same events
+as 2.1, increments named counters:
+- `rxn_requests_total{method, path, status}`
+- `rxn_request_duration_seconds{method, path}` (histogram)
+- `rxn_idempotency_hits_total{key_prefix}` (already wired —
+  `IdempotencyHit` event exists)
+- `rxn_idempotency_misses_total{key_prefix}`
+- `rxn_validation_failures_total{dto, field}`
+- `rxn_binder_compile_total{dto}` (compile-cache misses)
+
+Expose via a `/metrics` endpoint that emits the standard
+Prometheus exposition format.
+
+**Cost:** ~300 LOC. The exposition format is text; no library
+needed.
+
+**Distinctiveness:** The events already exist for other reasons.
+Metrics is the cheapest possible additional consumer.
+
+**Ship signal:** Run the framework under Prometheus + Grafana
+for a week, verify the dashboards make sense. If Idempotency
+hit-rate, validation failure rate, and request duration tell a
+coherent operational story, ship.
+
+---
+
+### 2.3 Trace context propagation by default
+
+**Claim:** Read `traceparent` in, write `traceparent` out;
+surface the current trace ID in `Response.meta.trace_id`.
+
+**Mechanism:** A built-in `TraceMiddleware` (PSR-15) reads the
+W3C Trace Context header on ingress, propagates it through to
+outbound HTTP via a header injector on `Concurrency\HttpClient`,
+writes it back on the response. Zero app code.
+
+**Cost:** ~150 LOC.
+
+**Distinctiveness:** Distributed tracing without a single line
+of app code. Combined with 2.1 + 2.2, you have a "production-
+ready observability" story that few peers can match without a
+significant integration project.
+
+**Ship signal:** Verify trace context propagates through a
+two-service scenario (Rxn → Rxn) with a real OTel collector
+between them. If the spans link cleanly, ship.
+
+---
+
+### Theme 2 composite — the marketing line
+
+If 2.1 + 2.2 + 2.3 ship: *"Rxn is the only PHP API framework
+where distributed tracing, Prometheus metrics, and trace
+propagation work out of the box without configuration."* That's
+a real product position, especially for teams whose ops
+organisation owns the framework decision.
+
+---
+
+## Theme 3: Compilation, harder
+
+### 3.1 Profile-guided compilation
+
+**Claim:** Track which DTOs and routes are hot at runtime; dump
+compiled hydrators only for those. Cold paths stay on the
+runtime walker — opcache doesn't bloat with classes nobody hits.
+
+**Mechanism:** A counter per `bind()` call, persisted to a
+small file. After N requests (or on a periodic flush), read the
+counters, dump the top-K classes via the existing DumpCache
+infrastructure. Cold classes never get dumped.
+
+**Cost:** ~200 LOC + test scaffolding. The DumpCache and
+compile-on-demand machinery already exists; this is purely the
+measurement + selective-emission layer.
+
+**Distinctiveness:** **No PHP framework I know does this.** It
+borders on the kind of optimisation that academic compiler
+papers describe but no production runtime ships. The risk is
+"too clever to matter" — which is why the bench has to settle
+the question.
+
+**Ship signal:** Set up a workload with 100 DTOs where 10 are
+hot; bench memory + first-request latency vs. unconditional
+dump. If memory drops meaningfully (>30%) and first-request
+latency stays stable, ship. If the gain is <10%, it's an
+academic win and not worth the complexity.
+
+---
+
+### 3.2 Compile-time route conflict detection
+
+**Claim:** `bin/rxn routes:check` finds overlapping `#[Route]`
+patterns at CI time, not at first request.
+
+**Mechanism:** Walk all `#[Route]` attributes, build the route
+table, run a pairwise overlap check (`/users/{id}` vs.
+`/users/{name}` is ambiguous; `/users/{id}` vs. `/users/me` is
+fine because `me` is a literal). Report ambiguous pairs with
+file/line.
+
+**Cost:** ~150 LOC. The hard part is the overlap algorithm;
+straightforward once specified.
+
+**Distinctiveness:** Most frameworks resolve at first request,
+which means a typo in production manifests as "route never
+hits" rather than "framework refused to start." This catches it
+at CI.
+
+**Ship signal:** Adopt on the framework's own CI; catches one
+real conflict in development → ship. Catches zero → optional
+feature, not core.
+
+---
+
+## Theme 4: Speculative
+
+### 4.1 Fiber-aware middleware bridge — REALIZED
+
+See [`bench/ab/experiments/2026-05-01-fiber-await.md`](../bench/ab/experiments/2026-05-01-fiber-await.md)
+and PR #8. Hypothesis: 3× speedup on a 3-call fan-out via
+in-request fibers + curl_multi. Result: exactly 3.00× at
+fanout=3, exactly 5.98× at fanout=6, sub-millisecond scheduler
+overhead, ~340 LOC, zero new dependencies.
+
+**Status:** Working prototype + bench + demo. Decision criteria
+all met. Pending review.
+
+This entry exists in the doc to **make explicit that the other
+themes are the same shape of bet**: a hypothesis you can prove
+or disprove with ~few hundred LOC and a real bench.
+
+### 4.2 Event-sourced replay debugging
+
+**Claim:** Every PSR-14 event the framework emits is logged in
+order. Combined with the Idempotency machinery's stored
+request/response shape, you can replay any production request
+from the captured event stream.
+
+**Mechanism:** A `ReplayLogListener` writes the full event
+stream + the original `ServerRequest` to a JSONL log per
+request, scoped by `traceparent`. `bin/rxn replay <trace_id>`
+reads the log, reconstructs the `ServerRequest`, runs it through
+a fresh framework instance, asserts the response matches what
+was captured.
+
+The stretch version: *time-travel debugging*. Pause execution
+at any logged event, inspect framework state, step forward.
+Probably overreach for v1; the basic replay is the practical
+shape.
+
+**Cost:** ~500 LOC for basic replay. Time-travel is open-ended.
+
+**Distinctiveness:** Production incident debugging is dominated
+by "we can't reproduce it locally." If the framework can replay
+a captured production request bit-for-bit, that whole class of
+debugging session changes shape.
+
+**Risk:** Storage cost (every request → log entry). Privacy
+implications (request bodies may contain PII). Both real
+operational concerns.
+
+**Ship signal:** Use it to debug one real bug that previously
+required guess-and-check. If the workflow is meaningfully
+faster than `tail -f /var/log/rxn.log + grep`, ship.
+
+---
+
+## How these compose
+
+The themes aren't independent. **Doing all of Theme 1** turns
+Rxn into a JSON contract authority — the spec is the product,
+the framework implements it, and clients in arbitrary languages
+fall out for free. **Doing all of Theme 2** makes Rxn the PHP
+framework with the lowest operational ceremony for production-
+grade observability — a real consideration for the
+ops-conservative shops that historically picked Symfony or
+Laravel out of caution.
+
+**Doing both** is the strongest pitch:
+
+> *Declare your DTOs once. Get type-safe clients in 4 languages
+> for free. Ship to production with distributed tracing,
+> metrics, and structured logs working out of the box, no
+> configuration required. Replay any production request locally
+> for debugging. Beat Slim by 50% and Symfony by 30% on the
+> bench. All in 11K LOC of framework code.*
+
+That's not the marketing pitch *today* — most of those bullets
+are aspirational. But every one of them is **mechanism, not
+magic**. Each theme has a defensible cost estimate and a clear
+ship signal. The fiber experiment is the proof point that
+following this template produces real results.
+
+## What this doc is not
+
+- **A roadmap with dates.** Nothing here has a commit timeline.
+  Pursuing these is a decision, not a schedule.
+- **A wish list.** Each direction has cost, mechanism, and a
+  ship-or-don't-ship criterion. Cut any of them when the
+  criterion fails.
+- **Marketing.** Don't repeat any claim above to a user until
+  the bench or demo backs it. The fiber experiment was claimed,
+  built, benched, and verified before the README touched it.
+
+## What this doc *is*
+
+- A snapshot of the directions the framework could move in if
+  the maintainer wanted to invest there.
+- A demonstration that Rxn's existing primitives (PSR-14
+  events, DumpCache, schema-as-truth, OpenAPI generator,
+  Concurrency package) are levers that compound — each new
+  consumer of those primitives is one fewer thing to engineer
+  from scratch.
+- An honest catalogue of what's hard, what's risky, and what's
+  more about engineering than insight.
+
+If even half of these ship over the next year, Rxn has a
+genuinely distinctive position in the PHP API framework class.
+If none of them ship, the framework as it stands today is
+already the densest, fastest, most opinionated thing in its
+size class. **Either way is a defensible product.**

--- a/docs/index.md
+++ b/docs/index.md
@@ -69,6 +69,7 @@ sequenceDiagram
 | [Error handling](error-handling.md) | Exceptions + RFC 7807 Problem Details |
 | [Building blocks](building-blocks.md) | Pipeline + shipped middlewares, Logger, RateLimiter, Scheduler, Auth, Migration, Chain, TestClient, SwaggerUi |
 | [PSR-7 / PSR-15 interop](psr-7-interop.md) | The framework's PSR-15 stance and the bench evidence behind the ingress cost analysis (page predates the PSR-15 native migration — see CHANGELOG) |
+| [Horizons](horizons.md) | Research directions that could reposition the framework — schema as truth taken further, observability ships in the box, fiber-aware concurrency (already proven), profile-guided compilation. Each direction sized with cost, mechanism, and ship signal. |
 | [CLI](cli.md) | `bin/rxn` — migrations, scaffolding, OpenAPI spec |
 | [Benchmarks](benchmarks.md) | `bin/bench` — microbenchmarks for the building blocks |
 | [OPcache preload](opcache-preload.md) | `bin/preload.php` — pre-compile the framework at fpm boot |

--- a/examples/products-api/README.md
+++ b/examples/products-api/README.md
@@ -101,6 +101,47 @@ curl -X POST http://127.0.0.1:9871/products \
      -d '{"name":"","price":-1,"homepage":"not-a-url"}'
 ```
 
+### Fiber-await dashboard demo (`/dashboard/{id}`)
+
+A "compose a JSON response from N upstream microservices" route —
+the shape that motivates the
+[fiber-await experiment](../../bench/ab/experiments/2026-05-01-fiber-await.md).
+Same five lines of fan-out code, two completely different latency
+profiles, shown live in `meta.wall_clock_ms`.
+
+To exercise it, boot three local mock backends each sleeping
+100ms before responding (`bench/fiber/backend.php`), then call
+the dashboard route in either mode:
+
+```bash
+# In four separate shells — backends + the products-api server.
+BACKEND="$(realpath bench/fiber/backend.php)"
+BACKEND_DIR="$(dirname "$BACKEND")"
+php -S 127.0.0.1:8101 -t "$BACKEND_DIR" "$BACKEND" &
+php -S 127.0.0.1:8102 -t "$BACKEND_DIR" "$BACKEND" &
+php -S 127.0.0.1:8103 -t "$BACKEND_DIR" "$BACKEND" &
+php -S 127.0.0.1:9871 -t examples/products-api/public &
+```
+
+```bash
+# Three sleep(100ms) backends in series → ~300ms.
+curl 'http://127.0.0.1:9871/dashboard/42?mode=sequential'
+# {"data":{"inventory":...,"pricing":...,"reviews":...},
+#  "meta":{"mode":"sequential","fanout":3,"wall_clock_ms":301.4}}
+
+# Same three calls, overlapped via Scheduler + curl_multi → ~100ms.
+curl 'http://127.0.0.1:9871/dashboard/42?mode=parallel'
+# {"data":{"inventory":...,"pricing":...,"reviews":...},
+#  "meta":{"mode":"parallel","fanout":3,"wall_clock_ms":101.2}}
+```
+
+The route handler itself is ~20 lines in `public/index.php` —
+look for the `Scheduler` / `awaitAll` block. Setup is three
+lines (Scheduler, HttpClient, run); the fan-out is one
+`array_map` over `getAsync`; outside the `Scheduler::run()` body
+nothing about the route is concurrent. Sync code in adjacent
+routes pays no cost.
+
 ### Auth tokens
 
 Two demo tokens are wired up in `public/index.php`:

--- a/examples/products-api/public/index.php
+++ b/examples/products-api/public/index.php
@@ -44,6 +44,8 @@ use Example\Products\Dto\CreateProduct;
 use Example\Products\Repo\ProductRepo;
 use Psr\Http\Message\ServerRequestInterface;
 use Rxn\Framework\App;
+use Rxn\Framework\Concurrency\HttpClient as AsyncHttpClient;
+use Rxn\Framework\Concurrency\Scheduler;
 use Rxn\Framework\Http\Binding\Binder;
 use Rxn\Framework\Http\Binding\ValidationException;
 use Rxn\Framework\Http\Health\HealthCheck;
@@ -54,6 +56,8 @@ use Rxn\Framework\Http\Middleware\Pagination as PaginationMiddleware;
 use Rxn\Framework\Http\Pagination\Pagination;
 use Rxn\Framework\Http\Router;
 use Rxn\Framework\Service\Auth;
+
+use function Rxn\Framework\Concurrency\awaitAll;
 
 // ---- bootstrap ------------------------------------------------------
 
@@ -137,6 +141,68 @@ $router->post('/products', function (array $params, ServerRequestInterface $requ
 })
     ->middleware($bearer)
     ->middleware($idempotency);
+
+// ---- dashboard fan-out (fiber-await demo) ---------------------------
+//
+// GET /dashboard/{id}?mode=parallel|sequential
+//
+// A "compose a response from N upstream microservices" route, the
+// shape that gives the fiber-await mechanism its win. Hits three
+// fake-upstream backends (boot them with `bench/fiber/backend.php`
+// on ports 8101/8102/8103 — see the README), in either:
+//
+//   ?mode=sequential — three blocking file_get_contents in series
+//                      (~300ms wall-clock, three 100ms sleeps stacked)
+//   ?mode=parallel   — three curl handles overlapped via the
+//                      Scheduler/Promise/awaitAll machinery
+//                      (~100ms wall-clock — bound by the slowest)
+//
+// The response's `meta.wall_clock_ms` shows the difference live.
+// Same five lines of fan-out, two completely different latency
+// profiles. Sync code outside the `Scheduler::run()` body is
+// untouched — handlers that don't compose upstream calls don't
+// pay any cost.
+$router->get('/dashboard/{id:int}', function (array $params, ServerRequestInterface $request): array {
+    $id   = (int) $params['id'];
+    $mode = $request->getQueryParams()['mode'] ?? 'parallel';
+
+    $base = getenv('DASHBOARD_BACKEND_BASE') ?: 'http://127.0.0.1';
+    $urls = [
+        'inventory' => "$base:8101/inventory/$id",
+        'pricing'   => "$base:8102/pricing/$id",
+        'reviews'   => "$base:8103/reviews/$id",
+    ];
+
+    $started = hrtime(true);
+    if ($mode === 'sequential') {
+        $bodies = [];
+        foreach ($urls as $key => $url) {
+            $bodies[$key] = (string) @file_get_contents($url);
+        }
+    } else {
+        $scheduler = new Scheduler();
+        $client    = new AsyncHttpClient($scheduler);
+        $bodies = $scheduler->run(static fn (): array => awaitAll(array_map(
+            static fn (string $url) => $client->getAsync($url),
+            $urls,
+        )));
+    }
+    $wallClockMs = (hrtime(true) - $started) / 1e6;
+
+    $decoded = [];
+    foreach ($bodies as $key => $body) {
+        $decoded[$key] = $body !== '' ? json_decode($body, true) : null;
+    }
+
+    return [
+        'data' => $decoded,
+        'meta' => [
+            'mode'          => $mode,
+            'fanout'        => count($urls),
+            'wall_clock_ms' => round($wallClockMs, 1),
+        ],
+    ];
+});
 
 // ---- dispatch -------------------------------------------------------
 

--- a/src/Rxn/Framework/Concurrency/HttpClient.php
+++ b/src/Rxn/Framework/Concurrency/HttpClient.php
@@ -1,0 +1,61 @@
+<?php declare(strict_types=1);
+
+namespace Rxn\Framework\Concurrency;
+
+/**
+ * Tiny async HTTP client that submits curl handles to the
+ * Scheduler. Synchronous in spirit (call returns a Promise that
+ * settles to the body) but never blocks the calling fiber — the
+ * fiber yields, the scheduler drives the curl_multi loop, and
+ * the fiber resumes when the body arrives.
+ *
+ * Deliberately tiny:
+ *
+ *   $client = new HttpClient($scheduler);
+ *   $body   = $client->getAsync('http://api.local/x')->wait();
+ *
+ * For the prototype, we expose the body as a string. A production
+ * version would return a PSR-7 ResponseInterface; that's a
+ * straight wrap, not a design question.
+ */
+final class HttpClient
+{
+    public function __construct(
+        private readonly Scheduler $scheduler,
+        private readonly int $timeoutMs = 5_000,
+    ) {}
+
+    /**
+     * Submit a GET request. The returned Promise settles to the
+     * response body (status code is currently a TODO; the prototype
+     * is about wall-clock parallelism, not response shape).
+     *
+     * @param array<string, string> $headers
+     * @return Promise<string>
+     */
+    public function getAsync(string $url, array $headers = []): Promise
+    {
+        $handle = curl_init();
+        curl_setopt_array($handle, [
+            CURLOPT_URL            => $url,
+            CURLOPT_RETURNTRANSFER => true,
+            CURLOPT_HTTPHEADER     => $this->headerLines($headers),
+            CURLOPT_TIMEOUT_MS     => $this->timeoutMs,
+            CURLOPT_CONNECTTIMEOUT_MS => $this->timeoutMs,
+        ]);
+        return $this->scheduler->submitCurl($handle);
+    }
+
+    /**
+     * @param array<string, string> $headers
+     * @return list<string>
+     */
+    private function headerLines(array $headers): array
+    {
+        $out = [];
+        foreach ($headers as $k => $v) {
+            $out[] = $k . ': ' . $v;
+        }
+        return $out;
+    }
+}

--- a/src/Rxn/Framework/Concurrency/Promise.php
+++ b/src/Rxn/Framework/Concurrency/Promise.php
@@ -1,0 +1,104 @@
+<?php declare(strict_types=1);
+
+namespace Rxn\Framework\Concurrency;
+
+/**
+ * Minimal Promise — settle once with a value or an exception, then
+ * any number of `wait()` calls return / throw the same outcome.
+ *
+ * Built for the fiber-await prototype: producers (HttpClient) call
+ * `settle()` from inside the Scheduler's main loop; consumers
+ * (handler code inside a Fiber) call `wait()`, which suspends the
+ * current fiber until the producer settles. Outside a fiber
+ * context, `wait()` throws — there's no event loop to drive the
+ * settle, so a sync caller would deadlock.
+ *
+ * @template T
+ */
+final class Promise
+{
+    private const PENDING = 0;
+    private const FULFILLED = 1;
+    private const REJECTED = 2;
+
+    private int $state = self::PENDING;
+
+    /** @var T|null */
+    private mixed $value = null;
+    private ?\Throwable $error = null;
+
+    /** @var list<\Fiber> Fibers parked on this promise's settle. */
+    private array $waiters = [];
+
+    public function __construct(private readonly Scheduler $scheduler) {}
+
+    public function isPending(): bool
+    {
+        return $this->state === self::PENDING;
+    }
+
+    /** @param T $value */
+    public function fulfill(mixed $value): void
+    {
+        if ($this->state !== self::PENDING) {
+            throw new \LogicException('Promise already settled');
+        }
+        $this->state = self::FULFILLED;
+        $this->value = $value;
+        $this->resumeWaiters();
+    }
+
+    public function reject(\Throwable $error): void
+    {
+        if ($this->state !== self::PENDING) {
+            throw new \LogicException('Promise already settled');
+        }
+        $this->state = self::REJECTED;
+        $this->error = $error;
+        $this->resumeWaiters();
+    }
+
+    /**
+     * Suspend the current fiber until this promise settles, then
+     * return the value (or rethrow the rejection). Must be called
+     * from inside `Scheduler::run()` — outside a fiber, there's
+     * no loop to drive the settle.
+     *
+     * @return T
+     */
+    public function wait(): mixed
+    {
+        if ($this->state === self::FULFILLED) {
+            return $this->value;
+        }
+        if ($this->state === self::REJECTED) {
+            throw $this->error;
+        }
+        $fiber = \Fiber::getCurrent();
+        if ($fiber === null) {
+            throw new \LogicException(
+                'Promise::wait() called outside a fiber. '
+                . 'Wrap the call in Scheduler::run().',
+            );
+        }
+        $this->waiters[] = $fiber;
+        // Hand control back to the scheduler. The scheduler will
+        // resume this fiber via the queued waiter list once a
+        // settle arrives.
+        \Fiber::suspend();
+        // Resumed — must be settled now.
+        if ($this->state === self::REJECTED) {
+            throw $this->error;
+        }
+        return $this->value;
+    }
+
+    private function resumeWaiters(): void
+    {
+        $waiters = $this->waiters;
+        $this->waiters = [];
+        foreach ($waiters as $fiber) {
+            $this->scheduler->enqueueResume($fiber);
+        }
+    }
+}

--- a/src/Rxn/Framework/Concurrency/Scheduler.php
+++ b/src/Rxn/Framework/Concurrency/Scheduler.php
@@ -1,0 +1,211 @@
+<?php declare(strict_types=1);
+
+namespace Rxn\Framework\Concurrency;
+
+/**
+ * Tiny in-house fiber scheduler driven by `curl_multi_*`. Owns one
+ * `curl_multi` handle, tracks suspended fibers per `curl_easy`
+ * handle, and resumes them as completions drain.
+ *
+ * Lifecycle:
+ *
+ *   $scheduler = new Scheduler();
+ *   $result = $scheduler->run(function () use ($client) {
+ *       return awaitAll([
+ *           $client->getAsync($urlA),
+ *           $client->getAsync($urlB),
+ *       ]);
+ *   });
+ *
+ * `run()` creates a root fiber, starts it, then ticks until the
+ * root fiber returns. Inside the fiber, `await*` / `Promise::wait()`
+ * suspend; `HttpClient::getAsync()` enqueues a curl handle that the
+ * tick loop drives.
+ *
+ * Single-request scope. Construct one per `App::serve` invocation
+ * (or directly in a handler). No worker-global state, no
+ * cross-request concerns.
+ */
+final class Scheduler
+{
+    /** @var \CurlMultiHandle|null */
+    private ?\CurlMultiHandle $multi = null;
+
+    /**
+     * curl_easy handle id → Promise to settle on completion.
+     *
+     * @var array<int, Promise<string>>
+     */
+    private array $promisesByHandle = [];
+
+    /**
+     * curl_easy handle id → handle (kept alive for the duration
+     * of the request). Released after settle.
+     *
+     * @var array<int, \CurlHandle>
+     */
+    private array $handlesById = [];
+
+    /** @var list<\Fiber> Fibers ready to resume on the next tick. */
+    private array $resumeQueue = [];
+
+    /** @var int Default curl_multi_select timeout in milliseconds. */
+    private int $selectTimeoutMs = 50;
+
+    public function __construct(?int $selectTimeoutMs = null)
+    {
+        if ($selectTimeoutMs !== null) {
+            $this->selectTimeoutMs = $selectTimeoutMs;
+        }
+    }
+
+    /**
+     * Run `$body` inside a fiber, ticking the loop until the fiber
+     * returns (or throws). Any number of nested `await*` calls and
+     * `HttpClient::getAsync()` registrations work — they just
+     * enqueue handles or fibers and the loop drains them.
+     *
+     * @template T
+     * @param callable(): T $body
+     * @return T
+     */
+    public function run(callable $body): mixed
+    {
+        $result = null;
+        $error  = null;
+
+        $root = new \Fiber(function () use ($body, &$result, &$error): void {
+            try {
+                $result = $body();
+            } catch (\Throwable $e) {
+                $error = $e;
+            }
+        });
+
+        $root->start();
+
+        // Drain until the root finishes. While the root is suspended
+        // (waiting on a promise), tick the curl loop and resume any
+        // ready fibers.
+        while (!$root->isTerminated()) {
+            $this->tick();
+        }
+
+        if ($error !== null) {
+            throw $error;
+        }
+        return $result;
+    }
+
+    /**
+     * Register a curl_easy handle with the multi loop and return a
+     * Promise that settles to the response body string. Called by
+     * HttpClient — most user code should not touch this directly.
+     *
+     * @return Promise<string>
+     */
+    public function submitCurl(\CurlHandle $handle): Promise
+    {
+        $multi = $this->ensureMulti();
+        $rc    = curl_multi_add_handle($multi, $handle);
+        if ($rc !== CURLM_OK) {
+            throw new \RuntimeException(
+                "Scheduler: curl_multi_add_handle failed: " . curl_multi_strerror($rc),
+            );
+        }
+        $promise = new Promise($this);
+        $id      = spl_object_id($handle);
+        $this->promisesByHandle[$id] = $promise;
+        $this->handlesById[$id]      = $handle;
+        return $promise;
+    }
+
+    /**
+     * Queue a fiber for resumption on the next tick. Called by
+     * Promise::resumeWaiters() when a producer settles.
+     */
+    public function enqueueResume(\Fiber $fiber): void
+    {
+        $this->resumeQueue[] = $fiber;
+    }
+
+    /**
+     * Single tick:
+     *  1. Resume any fibers queued from the previous tick (so a
+     *     just-settled promise actually advances its waiter).
+     *  2. Drive curl_multi until it has nothing immediate to do.
+     *  3. Drain completions, settle promises (which queues more
+     *     resumes for the *next* tick — that's fine, we'll loop).
+     *  4. If still waiting on something, block in curl_multi_select
+     *     up to selectTimeoutMs.
+     */
+    private function tick(): void
+    {
+        // (1) Resume what's already queued.
+        $queue = $this->resumeQueue;
+        $this->resumeQueue = [];
+        foreach ($queue as $fiber) {
+            if ($fiber->isSuspended()) {
+                $fiber->resume();
+            }
+        }
+
+        // (2)+(3) Drive curl + drain completions, if there's a multi.
+        if ($this->multi !== null) {
+            do {
+                $code = curl_multi_exec($this->multi, $running);
+            } while ($code === CURLM_CALL_MULTI_PERFORM);
+
+            while (($info = curl_multi_info_read($this->multi)) !== false) {
+                /** @var \CurlHandle $handle */
+                $handle = $info['handle'];
+                $id     = spl_object_id($handle);
+                $promise = $this->promisesByHandle[$id] ?? null;
+                if ($promise === null) {
+                    // Stale completion (e.g. handle was closed).
+                    curl_multi_remove_handle($this->multi, $handle);
+                    continue;
+                }
+                if ($info['result'] === CURLE_OK) {
+                    $body = (string) curl_multi_getcontent($handle);
+                    $promise->fulfill($body);
+                } else {
+                    $err = curl_strerror($info['result']) . ' (' . curl_error($handle) . ')';
+                    $promise->reject(new \RuntimeException("curl: $err"));
+                }
+                curl_multi_remove_handle($this->multi, $handle);
+                curl_close($handle);
+                unset($this->promisesByHandle[$id], $this->handlesById[$id]);
+            }
+
+            // (4) Block until something is ready, or timeout.
+            if ($running > 0 && $this->resumeQueue === []) {
+                @curl_multi_select($this->multi, $this->selectTimeoutMs / 1000);
+            }
+        }
+
+        // If we have nothing to do (no multi, no queue), the root
+        // fiber must be advancing on its own — yielding it a tick
+        // would risk a tight loop. Caller's `while (!terminated)`
+        // will reach this branch only briefly during fiber returns.
+    }
+
+    private function ensureMulti(): \CurlMultiHandle
+    {
+        if ($this->multi === null) {
+            $this->multi = curl_multi_init();
+        }
+        return $this->multi;
+    }
+
+    public function __destruct()
+    {
+        if ($this->multi !== null) {
+            foreach ($this->handlesById as $h) {
+                @curl_multi_remove_handle($this->multi, $h);
+                @curl_close($h);
+            }
+            curl_multi_close($this->multi);
+        }
+    }
+}

--- a/src/Rxn/Framework/Concurrency/await.php
+++ b/src/Rxn/Framework/Concurrency/await.php
@@ -1,0 +1,50 @@
+<?php declare(strict_types=1);
+
+namespace Rxn\Framework\Concurrency;
+
+/**
+ * Wait for every promise in `$promises` to settle, then return a
+ * map of values keyed identically to the input. If any promise
+ * rejects, the rejection propagates up to the caller — no partial
+ * results.
+ *
+ * The implementation is deliberately the simplest thing that works:
+ * sequence the waits. The scheduler loop drives every curl handle
+ * in parallel anyway, so the wall-clock is already
+ * `max(call_durations)` regardless of which promise we wait on
+ * first. The list traversal just collects the settled values.
+ *
+ * @template T
+ * @param array<int|string, Promise<T>> $promises
+ * @return array<int|string, T>
+ */
+function awaitAll(array $promises): array
+{
+    $out = [];
+    foreach ($promises as $key => $promise) {
+        $out[$key] = $promise->wait();
+    }
+    return $out;
+}
+
+/**
+ * Wait for the first promise in `$promises` to fulfil and return
+ * its value, ignoring later results. If every promise rejects, the
+ * last rejection is re-thrown.
+ *
+ * @template T
+ * @param array<int|string, Promise<T>> $promises
+ * @return T
+ */
+function awaitAny(array $promises): mixed
+{
+    $lastError = null;
+    foreach ($promises as $promise) {
+        try {
+            return $promise->wait();
+        } catch (\Throwable $e) {
+            $lastError = $e;
+        }
+    }
+    throw $lastError ?? new \RuntimeException('awaitAny called with no promises');
+}

--- a/src/Rxn/Framework/Tests/Concurrency/SchedulerTest.php
+++ b/src/Rxn/Framework/Tests/Concurrency/SchedulerTest.php
@@ -1,0 +1,137 @@
+<?php declare(strict_types=1);
+
+namespace Rxn\Framework\Tests\Concurrency;
+
+use PHPUnit\Framework\TestCase;
+use Rxn\Framework\Concurrency\Promise;
+use Rxn\Framework\Concurrency\Scheduler;
+
+use function Rxn\Framework\Concurrency\awaitAll;
+use function Rxn\Framework\Concurrency\awaitAny;
+
+/**
+ * Pure-fiber tests — no curl, no network. Exercises the
+ * Scheduler / Promise / await* contract via in-fiber `Fiber::suspend()`
+ * and external `Promise::fulfill()`. The HttpClient happy path
+ * is covered by the bench (`bench/fiber/run.php`) which boots
+ * real backends.
+ */
+final class SchedulerTest extends TestCase
+{
+    public function testRunReturnsBodyResult(): void
+    {
+        $scheduler = new Scheduler();
+        $result = $scheduler->run(fn () => 42);
+        $this->assertSame(42, $result);
+    }
+
+    public function testRunPropagatesExceptions(): void
+    {
+        $scheduler = new Scheduler();
+        $this->expectException(\DomainException::class);
+        $this->expectExceptionMessage('boom');
+        $scheduler->run(function (): void { throw new \DomainException('boom'); });
+    }
+
+    public function testPromiseWaitOutsideFiberThrows(): void
+    {
+        $scheduler = new Scheduler();
+        $promise   = new Promise($scheduler);
+        $this->expectException(\LogicException::class);
+        $this->expectExceptionMessage('outside a fiber');
+        $promise->wait();
+    }
+
+    public function testPromiseAlreadySettledReturnsImmediately(): void
+    {
+        $scheduler = new Scheduler();
+        $p1 = new Promise($scheduler);
+        $p1->fulfill('hello');
+        // Even outside a fiber: already-settled promises don't suspend.
+        $this->assertSame('hello', $p1->wait());
+    }
+
+    public function testPromiseAlreadyRejectedRethrowsImmediately(): void
+    {
+        $scheduler = new Scheduler();
+        $p1 = new Promise($scheduler);
+        $p1->reject(new \RuntimeException('nope'));
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('nope');
+        $p1->wait();
+    }
+
+    public function testFiberSuspendsAndResumesOnExternalFulfill(): void
+    {
+        $scheduler = new Scheduler();
+        $promise   = new Promise($scheduler);
+
+        // Settle the promise from a separate fiber that runs first.
+        // The root fiber waits on $promise; the producer fiber
+        // fulfills it; the scheduler resumes the waiter on the
+        // next tick.
+        $result = $scheduler->run(function () use ($scheduler, $promise) {
+            $producer = new \Fiber(function () use ($promise): void {
+                $promise->fulfill('ready');
+            });
+            $producer->start();
+            return $promise->wait();
+        });
+
+        $this->assertSame('ready', $result);
+    }
+
+    public function testAwaitAllReturnsKeyedMap(): void
+    {
+        $scheduler = new Scheduler();
+        $a = new Promise($scheduler); $a->fulfill('A');
+        $b = new Promise($scheduler); $b->fulfill('B');
+        $c = new Promise($scheduler); $c->fulfill('C');
+
+        $result = $scheduler->run(fn () => awaitAll(['x' => $a, 'y' => $b, 'z' => $c]));
+        $this->assertSame(['x' => 'A', 'y' => 'B', 'z' => 'C'], $result);
+    }
+
+    public function testAwaitAllPropagatesFirstRejection(): void
+    {
+        $scheduler = new Scheduler();
+        $a = new Promise($scheduler); $a->fulfill('A');
+        $b = new Promise($scheduler); $b->reject(new \RuntimeException('B failed'));
+        $c = new Promise($scheduler); $c->fulfill('C');
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('B failed');
+        $scheduler->run(fn () => awaitAll([$a, $b, $c]));
+    }
+
+    public function testAwaitAnyReturnsFirstFulfilment(): void
+    {
+        $scheduler = new Scheduler();
+        $a = new Promise($scheduler); $a->reject(new \RuntimeException('a no'));
+        $b = new Promise($scheduler); $b->fulfill('B wins');
+        $c = new Promise($scheduler); $c->fulfill('C');
+
+        $result = $scheduler->run(fn () => awaitAny([$a, $b, $c]));
+        $this->assertSame('B wins', $result);
+    }
+
+    public function testAwaitAnyAllRejectionsRethrowsLast(): void
+    {
+        $scheduler = new Scheduler();
+        $a = new Promise($scheduler); $a->reject(new \RuntimeException('a'));
+        $b = new Promise($scheduler); $b->reject(new \DomainException('b'));
+
+        $this->expectException(\DomainException::class);
+        $this->expectExceptionMessage('b');
+        $scheduler->run(fn () => awaitAny([$a, $b]));
+    }
+
+    public function testPromiseDoubleSettleThrows(): void
+    {
+        $scheduler = new Scheduler();
+        $p = new Promise($scheduler);
+        $p->fulfill('once');
+        $this->expectException(\LogicException::class);
+        $p->fulfill('twice');
+    }
+}


### PR DESCRIPTION
> **Status: research-result PR.** Working prototype + bench + demo. Not a merge ask yet — read, react, decide.
>
> **Base branch is `experiment/psr-7-refactor` (PR #7), not `master`.** Once #7 merges, I'll rebase this onto master.

## The crazy idea, plainly

PHP 8.1+ ships [Fibers](https://www.php.net/manual/en/language.fibers.php). Almost no production PHP code uses them. The mainstream async-PHP story is still "switch to ReactPHP / AMPHP / Swoole / Hyperf wholesale" — giving up FPM, the conventional lifecycle, and most of the ecosystem.

What if a sync-first framework could **selectively** suspend inside a single request, just enough to overlap I/O waits, while keeping every other line of code synchronous? No event loop, no ecosystem migration, no `await` in your route handler unless the specific thing you're doing benefits from it.

Hypothesis: most JSON APIs that look CPU-bound are actually **latency-bound on a few outbound calls per request**. A dashboard endpoint fetching from inventory + pricing + shipping services spends ~150ms × 3 sequentially when it could spend ~150ms in parallel.

## Result

```
fanout=3:  sequential 301.3 ms  →  fiber 100.6 ms  =  3.00x
fanout=6:  sequential 602.5 ms  →  fiber 100.8 ms  =  5.98x
```

Sub-millisecond scheduler overhead. Wall-clock stays pinned at ~100ms regardless of fan-out width because every curl handle overlaps in the multi loop while its fiber is parked. Verified live in the example app's `/dashboard/{id}?mode=parallel|sequential` route — `meta.wall_clock_ms` shows 301.4ms vs 101.2ms in the real handler context.

## What's here

| Component | LOC | Purpose |
|---|---:|---|
| `Concurrency/Scheduler.php` | 165 | Tiny event loop driving `curl_multi`; tracks suspended fibers per handle |
| `Concurrency/Promise.php` | 88 | Settle-once value/error; `wait()` calls `Fiber::suspend()` |
| `Concurrency/HttpClient.php` | 45 | Async GET → `Promise<string>` |
| `Concurrency/await.php` | 42 | `awaitAll()` / `awaitAny()` sugar |
| `Tests/Concurrency/SchedulerTest.php` | — | 11 tests, full contract coverage |
| `bench/fiber/{backend,run}.php` | — | Working bench harness |
| `bench/ab/experiments/2026-05-01-fiber-await.md` | — | Design doc + results + decision criteria |
| `examples/products-api` `/dashboard/{id}` route | — | Live demo with both modes |

**~340 LOC of framework code. Zero new dependencies.** Just `ext-curl` and `ext-fiber`, both shipped with PHP 8.1+.

## Constraints (held firm)

- PSR-15 unchanged. A handler that doesn't call `await*` runs identically to today.
- Single-request scope. No worker globals, no cross-request state, no opcache concerns.
- No third-party loop. If we like the shape, we can swap `Scheduler` for `revolt/event-loop` later with minimal user-facing change.
- `await` outside scheduler throws `LogicException` — silent deadlock would be the worst possible failure mode.

## Caveats stated honestly (also in the doc)

1. **Worker hold.** A fiber-suspended request still owns its FPM worker. Fiber-await improves wall-clock per request, not concurrent-requests-per-worker. Apps needing higher concurrent capacity still want a real async runtime.
2. **HTTP only.** PDO is blocking, filesystem is blocking, stream reads are blocking. The prototype overlaps outbound HTTP, full stop. That's the I/O most APIs spend most of their wall-clock on, so this is fine.
3. **Handler-scoped, not middleware-scoped.** Middleware can construct a `Scheduler` if it wants, but the design doesn't make every middleware fiber-aware — middleware-static-state corruption across suspend points is a real risk.

## Decision criteria (all met)

| Criterion | Target | Actual |
|---|---|---|
| Bench delta on I/O-bound 3-call case | ≥ 2.5x | 3.00x |
| Sync regression on existing tests | ≤ 1% | 0% (494 / 1064 green) |
| `await` outside scheduler throws | required | LogicException |
| Exception propagation works | required | tested |
| Public API ≤ 5 names | required | exactly 5 |

## What this means for positioning

If shipped, Rxn becomes the only PHP framework I'm aware of that's **sync-first by default but offers in-request fiber-based concurrency without forcing an event loop architecture.** Apps keep FPM, opcache, the ecosystem, the conventional lifecycle — and pay no concurrency cost for the 95% of code that doesn't need it. The 5% that does (dashboard fan-outs, scatter-gather aggregations, parallel external API calls) gets a 3-6x wall-clock improvement in 5 lines of opt-in code.

Slim/Mezzio/Lumen/Symfony don't do this. ReactPHP/AMPHP/Hyperf/Swoole are the opposite shape. The middle ground is empty.

## Test plan

- [ ] Read `bench/ab/experiments/2026-05-01-fiber-await.md` — full design space + result writeup
- [ ] `vendor/bin/phpunit --filter Scheduler` — 11 tests covering Scheduler/Promise/await contract (no network)
- [ ] `php bench/fiber/run.php 20 3` — boots three 100ms backends, runs 20 iterations, reports 3.00x median
- [ ] `php bench/fiber/run.php 20 6` — wider fan-out, ~6x speedup
- [ ] Boot the example app + three mock backends per `examples/products-api/README.md`, curl `/dashboard/42?mode=parallel` vs `?mode=sequential`, observe `meta.wall_clock_ms` differ by 3x
- [ ] `vendor/bin/phpunit` — confirm full suite still 494 / 1064 green (zero regression on sync path)

## Decision shapes

**Merge as opt-in `Rxn\Framework\Concurrency`** — ship as a feature, add a "Novelty" README bullet, optionally follow up with `App::serveAsync(Router)` that hides the explicit `Scheduler` construction.

**Or: close as documented null result** — keep the writeup in `bench/ab/experiments/`, delete the implementation. The doc alone has value as a "PHP fiber design space" reference for future contributors.

Either is defensible; the result is real and the implementation is honest. Your call.