### PR TITLE
fix(transaction): reset transaction state after outer commit

### DIFF
--- a/src/Rxn/Framework/Data/Database.php
+++ b/src/Rxn/Framework/Data/Database.php
@@ -363,6 +363,8 @@ class Database
             $error = $exception->getCode();
             throw new DatabaseException("PDO Exception (code $error)", 500, $exception);
         }
+        $this->transaction_depth--;
+        $this->in_transaction = false;
         return true;
     }
 

--- a/src/Rxn/Framework/Tests/Http/Middleware/TransactionTest.php
+++ b/src/Rxn/Framework/Tests/Http/Middleware/TransactionTest.php
@@ -117,6 +117,30 @@ final class TransactionTest extends TestCase
         $this->assertSame(0, (int)$count);
     }
 
+    public function testSequentialRequestsDoNotLeakTransactionState(): void
+    {
+        [$db, $pdo] = $this->makeDatabase();
+        $_SERVER['REQUEST_METHOD'] = 'POST';
+
+        $mw = new Transaction($db);
+        $mw->handle($this->bareRequest(), function () use ($pdo) {
+            $pdo->exec("INSERT INTO widgets (name) VALUES ('first commit')");
+            return $this->okResponse(201);
+        });
+
+        $response = $mw->handle($this->bareRequest(), function () use ($pdo) {
+            $pdo->exec("INSERT INTO widgets (name) VALUES ('should rollback after commit')");
+            return $this->okResponse(422);
+        });
+
+        $this->assertSame(422, $response->getCode());
+        $this->assertFalse($pdo->inTransaction());
+        $countCommitted = $pdo->query("SELECT COUNT(*) FROM widgets WHERE name = 'first commit'")->fetchColumn();
+        $countRolledBack = $pdo->query("SELECT COUNT(*) FROM widgets WHERE name = 'should rollback after commit'")->fetchColumn();
+        $this->assertSame(1, (int)$countCommitted);
+        $this->assertSame(0, (int)$countRolledBack);
+    }
+
     public function testCustomMethodList(): void
     {
         [$db, $pdo] = $this->makeDatabase();


### PR DESCRIPTION
### Motivation

- Prevent stale transaction bookkeeping in long-lived `Database` instances that allowed later failing requests to run without a real PDO transaction and silently persist partial writes. 

### Description

- Update `Database::transactionClose()` to decrement `transaction_depth` and clear `in_transaction` after the outermost `commit()` so state does not leak across requests. 
- Add a regression test `testSequentialRequestsDoNotLeakTransactionState()` in `src/Rxn/Framework/Tests/Http/Middleware/TransactionTest.php` that reuses the same `Transaction` middleware/`Database` instance across two POST requests (first commits, second returns 422 and must roll back). 
- Changes are confined to `src/Rxn/Framework/Data/Database.php` and the Transaction middleware tests under `src/Rxn/Framework/Tests/Http/Middleware/TransactionTest.php`. 

### Testing

- Added unit test `testSequentialRequestsDoNotLeakTransactionState()` to validate the fix; the test was committed with the change. 
- Attempted to run `phpunit src/Rxn/Framework/Tests/Http/Middleware/TransactionTest.php` but `phpunit` / `./vendor/bin/phpunit` are not available in the execution environment, so tests could not be executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f56abf6188832fbca920698da9a584)