### PR TITLE
Scope idempotency cache by auth principal and cap fingerprint body size

### DIFF
--- a/src/Rxn/Framework/Http/Middleware/Idempotency.php
+++ b/src/Rxn/Framework/Http/Middleware/Idempotency.php
@@ -54,6 +54,9 @@ final class Idempotency implements Middleware
     /** @var callable(): string Read the raw request body (for fingerprinting) */
     private $readBody;
 
+    /** @var callable(): string Optional scope (e.g. auth principal) added to key/fingerprint */
+    private $scopeResolver;
+
     public function __construct(
         private readonly IdempotencyStore $store,
         private readonly string $headerName     = 'Idempotency-Key',
@@ -61,11 +64,16 @@ final class Idempotency implements Middleware
         private readonly int    $lockTtlSeconds = 30,
         /** @var list<string> */
         private readonly array  $methods        = ['POST', 'PUT', 'PATCH', 'DELETE'],
+        private readonly int    $maxBodyBytes   = 1_048_576,
         ?callable $emitHeader = null,
         ?callable $readBody   = null,
+        ?callable $scopeResolver = null,
     ) {
         $this->emitHeader = $emitHeader ?? static fn (string $h) => header($h);
         $this->readBody   = $readBody   ?? static fn (): string => (string)file_get_contents('php://input');
+        $this->scopeResolver = $scopeResolver ?? static function (): string {
+            return (string)($_SERVER['HTTP_AUTHORIZATION'] ?? '');
+        };
     }
 
     public function handle(Request $request, callable $next): Response
@@ -79,10 +87,18 @@ final class Idempotency implements Middleware
             return $next($request);
         }
 
+        $scopedKey = $this->scopedKey($key);
         $fingerprint = $this->fingerprint($method);
+        if ($fingerprint === null) {
+            return $this->renderProblem(
+                413,
+                'idempotency_request_body_too_large',
+                'Request body exceeds idempotency fingerprint size limit.',
+            );
+        }
 
         // Replay path — cache hit.
-        $stored = $this->store->get($key);
+        $stored = $this->store->get($scopedKey);
         if ($stored !== null) {
             if ($stored->fingerprint !== $fingerprint) {
                 // Same key, different request shape → client bug.
@@ -97,7 +113,7 @@ final class Idempotency implements Middleware
         }
 
         // Cold path — acquire lock, process, store.
-        if (!$this->store->lock($key, $this->lockTtlSeconds)) {
+        if (!$this->store->lock($scopedKey, $this->lockTtlSeconds)) {
             return $this->renderProblem(
                 409,
                 'idempotency_key_in_use',
@@ -113,7 +129,7 @@ final class Idempotency implements Middleware
             // errors don't get cached as the canonical answer.
             if ($response->getCode() < 500) {
                 $this->store->put(
-                    $key,
+                    $scopedKey,
                     new StoredResponse(
                         statusCode:  $response->getCode(),
                         body:        $response->stripEmptyParams(),
@@ -125,7 +141,7 @@ final class Idempotency implements Middleware
             }
             return $response;
         } finally {
-            $this->store->release($key);
+            $this->store->release($scopedKey);
         }
     }
 
@@ -157,11 +173,21 @@ final class Idempotency implements Middleware
      * + raw request body. Query params are part of the URI and so
      * captured automatically.
      */
-    private function fingerprint(string $method): string
+    private function fingerprint(string $method): ?string
     {
         $uri  = $_SERVER['REQUEST_URI'] ?? '/';
+        $scope = (string)($this->scopeResolver)();
         $body = ($this->readBody)();
-        return hash('sha256', $method . "\n" . $uri . "\n" . $body);
+        if (strlen($body) > $this->maxBodyBytes) {
+            return null;
+        }
+        return hash('sha256', $scope . "\n" . $method . "\n" . $uri . "\n" . $body);
+    }
+
+    private function scopedKey(string $incomingKey): string
+    {
+        $scope = (string)($this->scopeResolver)();
+        return hash('sha256', $scope . "\n" . $incomingKey);
     }
 
     private function renderStored(StoredResponse $stored, Request $request): Response

--- a/src/Rxn/Framework/Tests/Http/Middleware/IdempotencyTest.php
+++ b/src/Rxn/Framework/Tests/Http/Middleware/IdempotencyTest.php
@@ -64,7 +64,7 @@ final class IdempotencyTest extends TestCase
             terminal: $this->terminalReturning(200, ['greeting' => 'hi']),
         );
         $this->assertSame(['greeting' => 'hi'], $response->data);
-        $this->assertNull($store->get('k-1'), 'GET should not have been recorded');
+        $this->assertCount(0, glob($this->tmpDir . '/*.json') ?: [], 'GET should not have been recorded');
     }
 
     public function testColdKeyStoresResponse(): void
@@ -74,7 +74,9 @@ final class IdempotencyTest extends TestCase
         $response = $this->runMiddleware($store, $headers, body: '{"a":1}', method: 'POST', terminal: $this->terminalReturning(201, ['id' => 42]));
         $this->assertSame(201, $response->getCode());
 
-        $stored = $store->get('k-cold');
+        $files = glob($this->tmpDir . '/*.json') ?: [];
+        $this->assertCount(1, $files);
+        $stored = StoredResponse::fromArray((array) json_decode((string) file_get_contents($files[0]), true));
         $this->assertInstanceOf(StoredResponse::class, $stored);
         $this->assertSame(201, $stored->statusCode);
         $this->assertSame(['id' => 42], $stored->body['data'] ?? null);
@@ -111,6 +113,45 @@ final class IdempotencyTest extends TestCase
         $this->assertContains('Idempotent-Replayed: true', $emittedHeaders);
     }
 
+
+    public function testSameKeyDoesNotReplayAcrossAuthorizationScopes(): void
+    {
+        $store = $this->makeFileStore();
+        $headers = ['HTTP_IDEMPOTENCY_KEY' => 'k-scope', 'HTTP_AUTHORIZATION' => 'Bearer alice'];
+
+        $alice = $this->runMiddleware($store, $headers, body: '{"a":1}', method: 'POST', terminal: $this->terminalReturning(201, ['id' => 'alice']));
+        $this->assertSame(['id' => 'alice'], $alice->data);
+
+        $count = 0;
+        $bob = $this->runMiddleware(
+            $store,
+            ['HTTP_IDEMPOTENCY_KEY' => 'k-scope', 'HTTP_AUTHORIZATION' => 'Bearer bob'],
+            body: '{"a":1}',
+            method: 'POST',
+            terminal: function () use (&$count): Response {
+                $count++;
+                return $this->terminalReturning(201, ['id' => 'bob'])();
+            },
+        );
+
+        $this->assertSame(1, $count, 'request with different auth scope should not replay cached response');
+        $this->assertSame(['id' => 'bob'], $bob->data);
+    }
+
+    public function testOversizedBodyReturns413(): void
+    {
+        $store = $this->makeFileStore();
+        $response = $this->runMiddleware(
+            $store,
+            ['HTTP_IDEMPOTENCY_KEY' => 'k-big'],
+            body: str_repeat('a', 20),
+            method: 'POST',
+            terminal: $this->terminalReturning(201, ['ok' => true]),
+            maxBodyBytes: 10,
+        );
+        $this->assertSame(413, $response->getCode());
+        $this->assertSame('idempotency_request_body_too_large', $response->meta['type']);
+    }
     public function testFingerprintMismatchReturns400(): void
     {
         $store = $this->makeFileStore();
@@ -130,13 +171,14 @@ final class IdempotencyTest extends TestCase
         $headers = ['HTTP_IDEMPOTENCY_KEY' => 'k-conflict'];
 
         // Acquire the lock manually to simulate "request in-flight".
-        $this->assertTrue($store->lock('k-conflict', 30));
+        $scopedKey = hash('sha256', "\n" . 'k-conflict');
+        $this->assertTrue($store->lock($scopedKey, 30));
 
         $response = $this->runMiddleware($store, $headers, body: '{"a":1}', method: 'POST', terminal: $this->terminalReturning(201, ['ok' => true]));
         $this->assertSame(409, $response->getCode());
         $this->assertSame('idempotency_key_in_use', $response->meta['type']);
 
-        $store->release('k-conflict');
+        $store->release($scopedKey);
     }
 
     public function test5xxResponsesAreNotCached(): void
@@ -151,7 +193,7 @@ final class IdempotencyTest extends TestCase
             method: 'POST',
             terminal: $this->terminalReturning(503, ['error' => 'down']),
         );
-        $this->assertNull($store->get('k-5xx'),
+        $this->assertCount(0, glob($this->tmpDir . '/*.json') ?: [],
             '5xx responses should not be cached so retries can hit a healthy backend');
     }
 
@@ -276,6 +318,7 @@ final class IdempotencyTest extends TestCase
         string $method,
         callable $terminal,
         ?callable $emitHeader = null,
+        int $maxBodyBytes = 1_048_576,
     ): Response {
         // Stash + restore $_SERVER so test isolation is real.
         $prevServer = $_SERVER;
@@ -287,6 +330,7 @@ final class IdempotencyTest extends TestCase
         try {
             $mw = new Idempotency(
                 $store,
+                maxBodyBytes: $maxBodyBytes,
                 emitHeader: $emitHeader,
                 readBody:   static fn (): string => $body,
             );


### PR DESCRIPTION
### Motivation
- The idempotency middleware used the raw `Idempotency-Key` header as a global store key and read the entire raw request body unbounded, enabling cross-principal replay and potential memory exhaustion.
- The intent is to prevent cached responses from being returned across different authenticated principals and to avoid unbounded `php://input` reads inside the middleware.

### Description
- Derive a scoped storage key and include an auth-derived scope in the fingerprint by adding a configurable `scopeResolver` (default: `Authorization` header) and applying `scopedKey()` to `get/put/lock/release` operations.
- Add a configurable `maxBodyBytes` constructor option (default 1_048_576) and make `fingerprint()` return `null` when the body exceeds this limit, causing the middleware to return a `413 idempotency_request_body_too_large` Problem Detail.
- Preserve existing replay/lock semantics and response-storage format while switching to the scoped key so behavior for a single principal is unchanged.
- Update tests to account for scoped keys, add `testSameKeyDoesNotReplayAcrossAuthorizationScopes` and `testOversizedBodyReturns413`, and adjust file-store assertions and the lock pre-acquire to use the scoped key.

### Testing
- Ran `php -l src/Rxn/Framework/Http/Middleware/Idempotency.php` which reported no syntax errors.
- Ran `php -l src/Rxn/Framework/Tests/Http/Middleware/IdempotencyTest.php` which reported no syntax errors.
- Attempted `./vendor/bin/phpunit src/Rxn/Framework/Tests/Http/Middleware/IdempotencyTest.php` but `phpunit` was not available in the execution environment so the full test suite could not be executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f56a3322ac832f9e396202413c3be1)