### PR TITLE
fix: enforce JsonBody size cap during stream read

### DIFF
--- a/src/Rxn/Framework/Http/Middleware/JsonBody.php
+++ b/src/Rxn/Framework/Http/Middleware/JsonBody.php
@@ -26,7 +26,7 @@ final class JsonBody implements Middleware
     private const BODY_METHODS = ['POST', 'PUT', 'PATCH'];
 
     private int $maxBytes;
-    /** @var callable(): string */
+    /** @var callable(int): string */
     private $readBody;
 
     /**
@@ -37,7 +37,26 @@ final class JsonBody implements Middleware
     public function __construct(int $maxBytes = 1048576, ?callable $readBody = null)
     {
         $this->maxBytes = $maxBytes;
-        $this->readBody = $readBody ?? static fn (): string => (string)file_get_contents('php://input');
+        $this->readBody = $readBody ?? static function (int $maxBytes): string {
+            $stream = fopen('php://input', 'rb');
+            if ($stream === false) {
+                return '';
+            }
+
+            $remaining = $maxBytes + 1;
+            $raw = '';
+            while ($remaining > 0 && !feof($stream)) {
+                $chunk = fread($stream, min(8192, $remaining));
+                if ($chunk === false || $chunk === '') {
+                    break;
+                }
+                $raw .= $chunk;
+                $remaining -= strlen($chunk);
+            }
+            fclose($stream);
+
+            return $raw;
+        };
     }
 
     public function handle(Request $request, callable $next): Response
@@ -67,7 +86,7 @@ final class JsonBody implements Middleware
             );
         }
 
-        $raw = ($this->readBody)();
+        $raw = ($this->readBody)($this->maxBytes);
         if ($raw === '') {
             return $next($request);
         }

--- a/src/Rxn/Framework/Tests/Http/Middleware/JsonBodyTest.php
+++ b/src/Rxn/Framework/Tests/Http/Middleware/JsonBodyTest.php
@@ -28,7 +28,7 @@ final class JsonBodyTest extends TestCase
 
     private function make(string $body, int $maxBytes = 1048576): JsonBody
     {
-        return new JsonBody($maxBytes, fn (): string => $body);
+        return new JsonBody($maxBytes, fn (int $_maxBytes): string => $body);
     }
 
     public function testDecodesValidJsonIntoPost(): void


### PR DESCRIPTION
### Motivation
- The `JsonBody` middleware previously used `file_get_contents('php://input')`, which can allocate the entire request body into memory and allow an attacker to exhaust PHP worker memory when `CONTENT_LENGTH` is absent or untrustworthy. 
- The change aims to enforce the configured `maxBytes` limit before a full allocation, restoring the intended in-code protection against oversized JSON payloads.

### Description
- Changed the injected reader signature to `callable(int): string` so the middleware can pass the configured `maxBytes` into the reader. 
- Replaced the default reader (`file_get_contents('php://input')`) with a streaming reader that opens `php://input` and reads in chunks up to `maxBytes + 1`, allowing early detection of oversized bodies without allocating the whole stream. 
- Updated the `JsonBody` invocation to call the reader with `$this->maxBytes` and adjusted the test helper in `JsonBodyTest` to match the new reader callable signature.

### Testing
- Ran `php -l` on `src/Rxn/Framework/Http/Middleware/JsonBody.php` which reported no syntax errors. 
- Ran `php -l` on `src/Rxn/Framework/Tests/Http/Middleware/JsonBodyTest.php` which reported no syntax errors. 
- Attempted to run the test suite with `vendor/bin/phpunit ...` but the `phpunit` binary/dependencies are not present in this environment, so unit tests could not be executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f56a1da0d8832f96f77cff0ff2bb36)