### PR TITLE
Harden CRUD write paths: restrict POST input and validate update columns

### DIFF
--- a/src/Rxn/Framework/Http/CrudController.php
+++ b/src/Rxn/Framework/Http/CrudController.php
@@ -53,7 +53,7 @@ class CrudController extends Controller implements Crud
      */
     public function create()
     {
-        $key_values = $this->request->getCollector()->getFromRequest();
+        $key_values = $this->request->getCollector()->getFromPost();
         $order      = $this->container->get($this->record_class);
         $created_id = $order->create($key_values);
         return ['created_id' => $created_id];
@@ -74,7 +74,7 @@ class CrudController extends Controller implements Crud
     public function update()
     {
         $record_id  = $this->request->getCollector()->getParamFromGet('id');
-        $key_values = $this->request->getCollector()->getFromRequest();
+        $key_values = $this->request->getCollector()->getFromPost();
         unset($key_values['id']);
         $order      = $this->container->get($this->record_class);
         $updated_id = $order->update($record_id, $key_values);

--- a/src/Rxn/Framework/Model/Record.php
+++ b/src/Rxn/Framework/Model/Record.php
@@ -146,13 +146,16 @@ abstract class Record extends Model
 
     public function update($record_id, array $key_values)
     {
-        // Reject attempts to mutate the primary key through an update;
-        // the WHERE clause below already binds its own column value.
-        if (array_key_exists($this->primary_key, $key_values)) {
-            throw new \Exception(
-                "'$this->primary_key' cannot be updated through this request as it is the primary key",
-                400
-            );
+        // Only allow updates to reflected table columns except the primary key.
+        $allowed_columns = array_diff($this->getColumns(), [$this->primary_key]);
+        $invalid_columns = array_diff(array_keys($key_values), $allowed_columns);
+        if (!empty($invalid_columns)) {
+            $invalid = implode(', ', $invalid_columns);
+            throw new \Exception("Update contains forbidden field(s): $invalid", 400);
+        }
+
+        if (empty($key_values)) {
+            throw new \Exception("Cannot update an empty record", 400);
         }
 
         $expressions = [];


### PR DESCRIPTION
### Motivation
- Prevent mass-assignment and request-driven identifier injection that allowed attacker-controlled request keys to become SQL identifiers in `Record::update()`.
- Reduce exposure from query/header parameters flowing into write paths by limiting CRUD write actions to POST body fields.
- Enforce schema-level whitelisting for updates so only reflected table columns (excluding the primary key) can be modified.

### Description
- Change `CrudController::create()` and `CrudController::update()` to read inputs from `getFromPost()` instead of `getFromRequest()` so headers and query params no longer flow into create/update payloads.
- Add validation in `Record::update()` that computes `allowed_columns = array_diff($this->getColumns(), [$this->primary_key])` and rejects any update keys not in that allowlist with a `400` error.
- Reject empty update payloads with a `400` error and preserve the existing binding/SQL generation and primary-key binding behavior.

### Testing
- Ran `php -l src/Rxn/Framework/Http/CrudController.php` and the file has no syntax errors.
- Ran `php -l src/Rxn/Framework/Model/Record.php` and the file has no syntax errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f56de7ffb0832fa20a5ae38db123f4)