### PR TITLE
docs(security): correct unsafe coroutine guidance for static auth context

### DIFF
--- a/docs/design-philosophy.md
+++ b/docs/design-philosophy.md
@@ -364,26 +364,21 @@ principles are how we keep the substrate healthy.
 ## Per-request state is sync-only by design
 
 `BearerAuth::current()` and `RequestId::current()` publish state
-through a `private static ?T $current` slot, set on `handle()`
-entry and cleared in `finally`. This is correct under any
-**synchronous** dispatch — including Swoole's default I/O-hooked
-fibers, where request handlers don't `Fiber::suspend()` between
-the set and the clear, so the static is observed only by the
-running request's own downstream code.
+through a process-wide `private static ?T $current` slot. That
+shape is only safe under strict one-request-at-a-time execution
+(e.g. PHP-FPM's process-per-request model).
 
-The shape is deliberate. The README's stated position is *"sync-
-first, process-per-request, predictable. We deliberately don't
-chase async."* Adding a per-fiber context map (one of the
-"obvious" robustness changes) would import shape the framework
-explicitly opts out of, for a hazard that only triggers when a
-handler holds principal across an explicit `Fiber::suspend()` —
-not a usage pattern the framework endorses or supports.
+It is **not** safe under concurrent coroutine/fiber workers
+(including I/O-hooked runtimes) because control can yield while
+`$current` is populated, allowing another in-flight request to
+overwrite the static before the first request resumes.
 
-If you have a handler that explicitly suspends a fiber while
-holding state, propagate that state yourself; don't rely on
-`current()`. This is the same boundary `rxn-orm` draws with
-`Record::clearConnections()` for fiber-isolated connection
-binding.
+The shape is deliberate: README positions rxn as *"sync-first,
+process-per-request, predictable. We deliberately don't chase
+async."* If you deploy on a concurrent worker model, do not rely
+on `current()`; carry request identity explicitly instead. This is
+the same boundary `rxn-orm` draws with `Record::clearConnections()`
+for fiber-isolated connection binding.
 
 ## Anti-patterns we deliberately avoid
 

--- a/src/Rxn/Framework/Http/Middleware/BearerAuth.php
+++ b/src/Rxn/Framework/Http/Middleware/BearerAuth.php
@@ -63,14 +63,15 @@ final class BearerAuth implements Middleware
      * `finally` so a long-lived worker doesn't leak the previous
      * request's principal into the next.
      *
-     * Sync-only by design: the framework targets PHP-FPM's
-     * process-per-request model (see README, "we deliberately don't
-     * chase async"). The clear-in-`finally` pattern is correct under
-     * any sync dispatch — including Swoole's default I/O-hooked
-     * fibers, where request handlers don't `Fiber::suspend()`
-     * between set and clear. If you have a handler that explicitly
-     * suspends a fiber while holding state, propagate the principal
-     * yourself; don't rely on this static.
+     * Sync-only by design: this static is process-wide and is only
+     * safe when requests are handled one-at-a-time (the framework's
+     * intended PHP-FPM model).
+     *
+     * In concurrent coroutine/fiber workers (including I/O-hooked
+     * runtimes), execution may yield while this value is set and
+     * another request may overwrite it before the original request
+     * resumes. In those environments, propagate identity explicitly;
+     * do not rely on this static.
      *
      * @return array<string, mixed>|null
      */


### PR DESCRIPTION
### Motivation

- Documentation and a docblock previously claimed `BearerAuth::current()` and `RequestId::current()` were safe under Swoole I/O-hooked fibers, which is misleading for concurrent coroutine/fiber deployments and can cause cross-request principal leakage.
- The goal is to remove unsafe guidance while preserving existing runtime behavior and the framework's sync-first design intent.

### Description

- Revised `docs/design-philosophy.md` to state that `current()` uses a process-wide `private static` slot and is only safe for strict one-request-at-a-time execution (e.g. PHP-FPM), and to explicitly warn that concurrent coroutine/fiber workers can yield while the static is set and allow overwrite.
- Updated the `BearerAuth::current()` docblock in `src/Rxn/Framework/Http/Middleware/BearerAuth.php` to remove the incorrect claim about hooked fibers and to document the concurrent-worker hazard and the required boundary (propagate identity explicitly in async/coroutine deployments).
- No runtime or API behavior was changed; this is a documentation-only safety correction.

### Testing

- Ran `php -l src/Rxn/Framework/Http/Middleware/BearerAuth.php` and the file linted with no syntax errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f57af4fc40832fbc8d1aaedcc4a63a)