### PR TITLE
fix(http): prevent Date/Json validator fatals on supported runtimes

### DIFF
--- a/src/Rxn/Framework/Http/Attribute/Date.php
+++ b/src/Rxn/Framework/Http/Attribute/Date.php
@@ -18,6 +18,9 @@ final class Date implements Validates
         if (!is_string($value)) {
             return null;
         }
+        if (\str_contains($value, "\0")) {
+            return 'must be a valid date (YYYY-MM-DD)';
+        }
         $parsed = \DateTimeImmutable::createFromFormat('!Y-m-d', $value);
         return $parsed !== false && $parsed->format('Y-m-d') === $value
             ? null

--- a/src/Rxn/Framework/Http/Attribute/Json.php
+++ b/src/Rxn/Framework/Http/Attribute/Json.php
@@ -16,6 +16,15 @@ final class Json implements Validates
         if (!is_string($value)) {
             return null;
         }
-        return json_validate($value) ? null : 'must be valid JSON';
+        if (\function_exists('json_validate')) {
+            return \json_validate($value) ? null : 'must be valid JSON';
+        }
+
+        try {
+            \json_decode($value, true, 512, JSON_THROW_ON_ERROR);
+            return null;
+        } catch (\JsonException) {
+            return 'must be valid JSON';
+        }
     }
 }

--- a/src/Rxn/Framework/Http/Binding/Binder.php
+++ b/src/Rxn/Framework/Http/Binding/Binder.php
@@ -348,17 +348,30 @@ final class Binder
 
     private static function inlineJson(string $valueExpr, string $fieldQ): string
     {
-        return "        if (\\is_string($valueExpr) && !\\json_validate($valueExpr)) {\n"
-             . "            \$errors[] = ['field' => $fieldQ, 'message' => 'must be valid JSON'];\n"
+        return "        if (\\is_string($valueExpr)) {\n"
+             . "            if (\\function_exists('json_validate')) {\n"
+             . "                if (!\\json_validate($valueExpr)) {\n"
+             . "                    \$errors[] = ['field' => $fieldQ, 'message' => 'must be valid JSON'];\n"
+             . "                }\n"
+             . "            } else {\n"
+             . "                try {\n"
+             . "                    \\json_decode($valueExpr, true, 512, \\JSON_THROW_ON_ERROR);\n"
+             . "                } catch (\\JsonException) {\n"
+             . "                    \$errors[] = ['field' => $fieldQ, 'message' => 'must be valid JSON'];\n"
+             . "                }\n"
+             . "            }\n"
              . "        }\n";
     }
 
     private static function inlineDate(string $valueExpr, string $fieldQ): string
     {
         return "        if (\\is_string($valueExpr)) {\n"
-             . "            \$dt = \\DateTimeImmutable::createFromFormat('!Y-m-d', $valueExpr);\n"
-             . "            if (\$dt === false || \$dt->format('Y-m-d') !== $valueExpr) {\n"
+             . "            if (\\str_contains($valueExpr, \"\0\")) {\n"
              . "                \$errors[] = ['field' => $fieldQ, 'message' => 'must be a valid date (YYYY-MM-DD)'];\n"
+             . "            } else {\n"
+             . "                \$dt = \\DateTimeImmutable::createFromFormat('!Y-m-d', $valueExpr);\n"             . "                if (\$dt === false || \$dt->format('Y-m-d') !== $valueExpr) {\n"
+             . "                    \$errors[] = ['field' => $fieldQ, 'message' => 'must be a valid date (YYYY-MM-DD)'];\n"
+             . "                }\n"
              . "            }\n"
              . "        }\n";
     }

--- a/src/Rxn/Framework/Tests/Http/Attribute/AttributeParityTest.php
+++ b/src/Rxn/Framework/Tests/Http/Attribute/AttributeParityTest.php
@@ -84,10 +84,11 @@ final class AttributeParityTest extends TestCase
         $this->assertNotNull((new Date())->validate('2024-02-30'));    // phantom day
         $this->assertNotNull((new Date())->validate('04/29/2026'));    // wrong format
         $this->assertNotNull((new Date())->validate('tomorrow'));      // strtotime-ism
+        $this->assertNotNull((new Date())->validate("2026-04-29\0"));   // embedded NUL
 
         $this->assertParity(DateDto::class,
             valid:   ['birthday' => '1990-01-15'],
-            invalid: ['birthday' => 'tomorrow'],
+            invalid: ['birthday' => "1990-01-15\0"],
             field:   'birthday',
         );
     }


### PR DESCRIPTION
### Motivation
- The new DTO `#[Date]` and `#[Json]` validators could cause uncaught `Error/ValueError` on attacker-controlled input because `DateTimeImmutable::createFromFormat()` throws `ValueError` on embedded NUL bytes and `json_validate()` is a PHP 8.3 function while `composer.json` declares `^8.2` support.
- Both the runtime `Binder::bind` path and the compiled `Binder` inliners emitted the unsafe calls, so affected endpoints could crash instead of returning `ValidationException` responses.

### Description
- Added a NUL-byte guard in `Date::validate` that returns a validation error when `\str_contains($value, "\0")` is true to avoid calling `DateTimeImmutable::createFromFormat` on dangerous input.
- Made `Json::validate` use `\json_validate()` only when available and otherwise fall back to `\json_decode(..., JSON_THROW_ON_ERROR)` with `\JsonException` handling to remain compatible with PHP `^8.2`.
- Updated `Binder::inlineJson` and `Binder::inlineDate` to emit matching safe checks so compiled binders preserve runtime/compiled parity.
- Extended `AttributeParityTest` to include an embedded NUL-byte invalid case for the `Date` attribute to assert both paths behave identically.

### Testing
- Ran PHP lint (`php -l`) on the modified files (`src/Rxn/Framework/Http/Attribute/Date.php`, `src/Rxn/Framework/Http/Attribute/Json.php`, `src/Rxn/Framework/Http/Binding/Binder.php`) and there were no syntax errors.
- Attempted to run the test suite with `vendor/bin/phpunit`, but `phpunit` is not present in this environment so the PHPUnit run could not be executed here.
- The updated unit test `AttributeParityTest` now includes the NUL-byte case and will exercise the change when CI runs the project's PHPUnit suite.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f579d2af9c832f8e7ce44cfeb6279e)