### PR TITLE
fix(binding): preserve constructor-free DTO instantiation in compiled Binder

### DIFF
--- a/src/Rxn/Framework/Http/Binding/Binder.php
+++ b/src/Rxn/Framework/Http/Binding/Binder.php
@@ -166,8 +166,9 @@ final class Binder
         // at compile time, dispatched by index from the closure's
         // `use ($validators)`.
         $validators = [];
+        $dtoFactory = static fn () => $reflection->newInstanceWithoutConstructor();
         $body = "    \$errors = [];\n";
-        $body .= "    \$dto = new \\" . ltrim($class, '\\') . "();\n";
+        $body .= "    \$dto = \$dtoFactory();\n";
         foreach ($reflection->getProperties(\ReflectionProperty::IS_PUBLIC) as $prop) {
             if ($prop->isStatic()) {
                 continue;
@@ -179,7 +180,7 @@ final class Binder
               .  "    }\n"
               .  "    return \$dto;\n";
 
-        $code = "return static function (array \$bag) use (\$validators): \\" . ltrim($class, '\\')
+        $code = "return static function (array \$bag) use (\$validators, \$dtoFactory): \\" . ltrim($class, '\\')
               . " {\n" . $body . "};";
 
         /** @var \Closure(array): RequestDto $closure */


### PR DESCRIPTION
### Motivation
- Ensure `Binder::compileFor()` preserves the same constructor-free instantiation semantics as `Binder::bind()` to avoid leaking constructor-initialized values for omitted request fields and to prevent request-triggered constructor errors in compiled mode.

### Description
- Replace direct `new Class()` generation with a compile-time `$dtoFactory` that calls `ReflectionClass::newInstanceWithoutConstructor()` and capture it in the generated closure so compiled binders create DTOs without invoking constructors; change made in `src/Rxn/Framework/Http/Binding/Binder.php`.

### Testing
- Ran `php -l src/Rxn/Framework/Http/Binding/Binder.php` which reported no syntax errors; 
- Attempted `vendor/bin/phpunit src/Rxn/Framework/Tests/Http/Binding/BinderTest.php` and `phpunit ...` but the PHPUnit binary is not available in this environment so unit tests were not executed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f584d75fb0832f8001758d5ff10bf8)