### PR TITLE
fix(validator): avoid fatal errors in json/date/datetime rules

### DIFF
--- a/src/Rxn/Framework/Tests/Utility/ValidatorTest.php
+++ b/src/Rxn/Framework/Tests/Utility/ValidatorTest.php
@@ -252,14 +252,17 @@ final class ValidatorTest extends TestCase
         yield 'json object'       => ['json', '{"a":1}', true];
         yield 'json array'        => ['json', '[1,2,3]', true];
         yield 'json invalid'      => ['json', 'not json', false];
+        yield 'json with null byte escape' => ['json', "\"\\u0000\"", true];
         yield 'date valid'        => ['date', '2026-04-29', true];
         yield 'date bad month'    => ['date', '2026-13-01', false];
         yield 'date phantom day'  => ['date', '2024-02-30', false];
+        yield 'date embedded null byte' => ['date', "2026-04-29\0", false];
         yield 'date wrong format' => ['date', '04/29/2026', false];
         yield 'datetime ISO Z'    => ['datetime', '2026-04-29T12:34:56Z', true];
         yield 'datetime ISO offset' => ['datetime', '2026-04-29T12:34:56+00:00', true];
         yield 'datetime SQL'      => ['datetime', '2026-04-29 12:34:56', true];
         yield 'datetime invalid'  => ['datetime', 'tomorrow', false];
+        yield 'datetime embedded null byte' => ['datetime', "2026-04-29T12:34:56Z\0", false];
         yield 'not_blank space-only' => ['not_blank', '   ', false];
         yield 'not_blank tab-only'   => ['not_blank', "\t\n", false];
         yield 'not_blank ok'      => ['not_blank', 'hi', true];

--- a/src/Rxn/Framework/Utility/Validator.php
+++ b/src/Rxn/Framework/Utility/Validator.php
@@ -243,7 +243,7 @@ final class Validator
                     ? null
                     : "$field must be a valid IPv6 address";
             case 'json':
-                return is_string($value) && json_validate($value)
+                return self::isValidJson($value)
                     ? null
                     : "$field must be valid JSON";
             case 'date':
@@ -403,7 +403,7 @@ final class Validator
             'ip'     => "        if (!(\\is_string(\$value) && \\filter_var(\$value, \\FILTER_VALIDATE_IP) !== false)) { \$errors[$fieldQ][] = " . self::quoteString("$field must be a valid IP address") . "; }\n",
             'ipv4'   => "        if (!(\\is_string(\$value) && \\filter_var(\$value, \\FILTER_VALIDATE_IP, \\FILTER_FLAG_IPV4) !== false)) { \$errors[$fieldQ][] = " . self::quoteString("$field must be a valid IPv4 address") . "; }\n",
             'ipv6'   => "        if (!(\\is_string(\$value) && \\filter_var(\$value, \\FILTER_VALIDATE_IP, \\FILTER_FLAG_IPV6) !== false)) { \$errors[$fieldQ][] = " . self::quoteString("$field must be a valid IPv6 address") . "; }\n",
-            'json'   => "        if (!(\\is_string(\$value) && \\json_validate(\$value))) { \$errors[$fieldQ][] = " . self::quoteString("$field must be valid JSON") . "; }\n",
+            'json'   => "        if (!\\Rxn\\Framework\\Utility\\Validator::isValidJson(\$value)) { \$errors[$fieldQ][] = " . self::quoteString("$field must be valid JSON") . "; }\n",
             'date'    => self::compileDateRule($field, 'Y-m-d', "$field must be a valid date (YYYY-MM-DD)"),
             'datetime'=> self::compileDateTimeRule($field),
             'not_blank' => "        if (!(\\is_string(\$value) && \\trim(\$value) !== '')) { \$errors[$fieldQ][] = " . self::quoteString("$field must not be blank") . "; }\n",
@@ -420,8 +420,12 @@ final class Validator
         $msgQ     = self::quoteString($message);
         return "        if (!\\is_string(\$value)) { \$errors[$fieldQ][] = $msgQ; }\n"
              . "        else {\n"
-             . "            \$dt = \\DateTimeImmutable::createFromFormat('!' . $formatQ, \$value);\n"
-             . "            if (\$dt === false || \$dt->format($formatQ) !== \$value) { \$errors[$fieldQ][] = $msgQ; }\n"
+             . "            try {\n"
+             . "                \$dt = \\DateTimeImmutable::createFromFormat('!' . $formatQ, \$value);\n"
+             . "                if (\$dt === false || \$dt->format($formatQ) !== \$value) { \$errors[$fieldQ][] = $msgQ; }\n"
+             . "            } catch (\\ValueError) {\n"
+             . "                \$errors[$fieldQ][] = $msgQ;\n"
+             . "            }\n"
              . "        }\n";
     }
 
@@ -435,8 +439,13 @@ final class Validator
              . "        else {\n"
              . "            \$ok = false;\n"
              . "            foreach ([\\DateTimeInterface::RFC3339, \\DateTimeInterface::ATOM, 'Y-m-d\\\\TH:i:s\\\\Z', 'Y-m-d\\\\TH:i:sP', 'Y-m-d H:i:s'] as \$f) {\n"
-             . "                \$dt = \\DateTimeImmutable::createFromFormat(\$f, \$value);\n"
-             . "                if (\$dt !== false && \$dt->format(\$f) === \$value) { \$ok = true; break; }\n"
+             . "                try {\n"
+             . "                    \$dt = \\DateTimeImmutable::createFromFormat(\$f, \$value);\n"
+             . "                    if (\$dt !== false && \$dt->format(\$f) === \$value) { \$ok = true; break; }\n"
+             . "                } catch (\\ValueError) {\n"
+             . "                    \$ok = false;\n"
+             . "                    break;\n"
+             . "                }\n"
              . "            }\n"
              . "            if (!\$ok) { \$errors[$fieldQ][] = $msgQ; }\n"
              . "        }\n";
@@ -530,7 +539,11 @@ final class Validator
         if (!is_string($value)) {
             return false;
         }
-        $parsed = \DateTimeImmutable::createFromFormat('!' . $format, $value);
+        try {
+            $parsed = \DateTimeImmutable::createFromFormat('!' . $format, $value);
+        } catch (\ValueError) {
+            return false;
+        }
         if ($parsed === false) {
             return false;
         }
@@ -556,12 +569,30 @@ final class Validator
             'Y-m-d H:i:s',
         ];
         foreach ($formats as $format) {
-            $parsed = \DateTimeImmutable::createFromFormat($format, $value);
+            try {
+                $parsed = \DateTimeImmutable::createFromFormat($format, $value);
+            } catch (\ValueError) {
+                return false;
+            }
             if ($parsed !== false && $parsed->format($format) === $value) {
                 return true;
             }
         }
         return false;
+    }
+
+    public static function isValidJson(mixed $value): bool
+    {
+        if (!is_string($value)) {
+            return false;
+        }
+
+        if (function_exists('json_validate')) {
+            return json_validate($value);
+        }
+
+        json_decode($value);
+        return json_last_error() === JSON_ERROR_NONE;
     }
 
     /**


### PR DESCRIPTION
### Motivation
- New `json`, `date` and `datetime` rules could raise fatal errors on attacker-controlled input because `DateTimeImmutable::createFromFormat()` throws `ValueError` on NUL bytes and `json_validate()` is only available on PHP 8.3+, while the project supports `^8.2`.
- The intent is to ensure malformed or adversarial input becomes a validation failure rather than an uncaught runtime crash, and to keep runtime and compiled validation paths behaviourally identical.

### Description
- Replaced direct `json_validate()` use in rule dispatch with a new `Validator::isValidJson()` helper that uses `json_validate()` when available and falls back to `json_decode()` + `json_last_error()` for older PHP versions.
- Added `try/catch (\ValueError)` around `DateTimeImmutable::createFromFormat()` in the runtime helpers `isValidDate()` and `isValidDateTime()` so NUL-byte or other inputs that raise `ValueError` result in a validation failure (`false`).
- Updated the compiled-rule generator to emit `try/catch (\ValueError)` handling in the generated code for both `date` and `datetime` compiled fragments so the fast path matches runtime safety.
- Extended the test data provider in `src/Rxn/Framework/Tests/Utility/ValidatorTest.php` with regression cases for JSON NUL escape and embedded NUL bytes in `date`/`datetime` inputs.

### Testing
- Lint: ran `php -l src/Rxn/Framework/Utility/Validator.php` and `php -l src/Rxn/Framework/Tests/Utility/ValidatorTest.php`, both reported no syntax errors (succeeded).
- Unit tests: attempted `vendor/bin/phpunit src/Rxn/Framework/Tests/Utility/ValidatorTest.php` and `phpunit ...` but `phpunit` is not installed in this environment (could not run full test suite here).
- Added regression cases to the existing PHPUnit provider so runtime and compiled tests will exercise the fixed paths when `phpunit` is executed in CI or a developer environment (not executed in this container).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f583d801d4832f9077604a76a93179)