### PR TITLE
fix: restore ActiveRecord::hydrate use of overrideable fromRow hook

### DIFF
--- a/src/Rxn/Framework/Model/ActiveRecord.php
+++ b/src/Rxn/Framework/Model/ActiveRecord.php
@@ -84,17 +84,10 @@ abstract class ActiveRecord
         if (!is_subclass_of($class, self::class)) {
             throw new \InvalidArgumentException("$class is not an ActiveRecord");
         }
-        // Inline the per-row construction. array_map+fromRow does
-        // a closure call + a static method dispatch per row; this
-        // body collapses both into one `new $class()` and a direct
-        // property write, sustainably faster on big result sets.
-        $out = [];
-        foreach ($rows as $r) {
-            $instance = new $class();
-            $instance->attributes = $r;
-            $out[] = $instance;
-        }
-        return $out;
+        return array_map(
+            fn (array $r): ActiveRecord => $class::fromRow($r),
+            $rows
+        );
     }
 
     /**


### PR DESCRIPTION
### Motivation
- A recent optimization in `ActiveRecord::hydrate()` instantiated classes and wrote raw attributes directly, which bypassed the public, overrideable `fromRow()` hook used by subclasses to sanitize or transform rows. 
- That regression can leak sensitive columns (e.g. `password_hash`, `api_token`) when callers bulk-hydrate records and then serialize them, and can crash for subclasses with non-trivial constructors.
- The change restores consistent behavior with `find()` which already delegates single-row hydration to `static::fromRow()`.

### Description
- Replaced the inline instantiation + direct `$instance->attributes = $r` loop in `src/Rxn/Framework/Model/ActiveRecord.php` with delegation to the overrideable hook via `return array_map(fn (array $r): ActiveRecord => $class::fromRow($r), $rows);` inside `hydrate()`.
- This preserves subclass `fromRow()` overrides for redaction, casting, decryption, constructor-safe instantiation, and other invariants while keeping the public API the same.
- Only `ActiveRecord::hydrate()` was changed; no other public APIs were modified.

### Testing
- Attempted to run unit tests with `./vendor/bin/phpunit src/Rxn/Framework/Tests/Model/ActiveRecordTest.php`, but `./vendor/bin/phpunit` is not present in this environment so tests could not be executed.
- Attempted `phpunit src/Rxn/Framework/Tests/Model/ActiveRecordTest.php` using a global binary, but `phpunit` is not installed in the container so tests could not be executed.
- No automated tests were run successfully in this environment; the patch is intentionally minimal to preserve existing behavior covered by the test-suite when run in a full development environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f589626370832fa9fbe868828118dc)