### PR TITLE
fix(router): encode named route URL params as path segments

### DIFF
--- a/src/Rxn/Framework/Http/Router.php
+++ b/src/Rxn/Framework/Http/Router.php
@@ -172,7 +172,7 @@ final class Router
             // Covers both `{id}` and `{id:int}` forms.
             $url = preg_replace(
                 '/\{' . preg_quote($placeholder, '/') . '(?::[a-zA-Z_][a-zA-Z0-9_]*)?\}/',
-                (string)$params[$placeholder],
+                rawurlencode((string)$params[$placeholder]),
                 $url
             );
         }

--- a/src/Rxn/Framework/Tests/Http/RouterTest.php
+++ b/src/Rxn/Framework/Tests/Http/RouterTest.php
@@ -175,6 +175,23 @@ final class RouterTest extends TestCase
         $this->assertSame('/products/42', $r->url('products.show', ['id' => 42]));
     }
 
+
+    public function testNamedRouteUrlEncodesPathSegmentCharacters(): void
+    {
+        $r = new Router();
+        $r->get('/products/{id}', 'show')->name('products.show');
+
+        $this->assertSame('/products/a%2Fb', $r->url('products.show', ['id' => 'a/b']));
+        $this->assertSame('/products/foo%3Fadmin%3Dtrue%23frag', $r->url('products.show', ['id' => 'foo?admin=true#frag']));
+    }
+
+    public function testNamedRouteUrlDoesNotProduceSchemeRelativeUrlFromRootPlaceholder(): void
+    {
+        $r = new Router();
+        $r->get('/{target}', 'go')->name('go');
+
+        $this->assertSame('/%2Fevil.example', $r->url('go', ['target' => '/evil.example']));
+    }
     public function testUrlRejectsUnknownName(): void
     {
         $r = new Router();


### PR DESCRIPTION
### Motivation
- The named-route generator `Router::url()` substituted route placeholders directly into patterns, allowing values containing `/`, `?`, `#`, or a leading `/` to change URL structure and enable link confusion or open-redirect style issues.
- Route matching compiles placeholders as single path segments (`([^/]+)`), so reverse-generation must percent-encode segment values to preserve structure.

### Description
- Updated `Router::url()` to percent-encode each placeholder value with `rawurlencode((string)$value)` before substituting into the route `pattern` to ensure values remain a single path segment.
- The change preserves existing API surface and error behavior (lookup via `indexNames()`, `InvalidArgumentException` for missing name/params, support for typed placeholder forms like `{id:int}`).
- Added two focused PHPUnit tests in `src/Rxn/Framework/Tests/Http/RouterTest.php` that assert path-segment encoding for `/`, `?`, `#` characters and that a root-level placeholder cannot produce a scheme-relative URL.

### Testing
- Added unit tests: `testNamedRouteUrlEncodesPathSegmentCharacters` and `testNamedRouteUrlDoesNotProduceSchemeRelativeUrlFromRootPlaceholder` in `src/Rxn/Framework/Tests/Http/RouterTest.php` (not executed in this environment).
- Attempted to run the test suite via `composer test` and directly via `vendor/bin/phpunit`, but the environment lacks the `phpunit` binary so automated tests could not be executed here (both attempts failed with `phpunit: not found`).
- No other automated test failures were observed because the test runner was not available in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f584d80c18832fa1a6ad571fed5b7d)