### PR TITLE
fix: constrain FK reflection join to source table

### DIFF
--- a/src/Rxn/Framework/Data/Map/Table.php
+++ b/src/Rxn/Framework/Data/Map/Table.php
@@ -152,6 +152,8 @@ class Table extends Service
             FROM information_schema.columns AS c
             LEFT JOIN information_schema.key_column_usage AS kcu
                 ON kcu.column_name = c.column_name
+                    AND kcu.table_schema = c.table_schema
+                    AND kcu.table_name = c.table_name
                     AND kcu.referenced_table_schema LIKE :database_name
                     AND kcu.referenced_table_name IS NOT NULL
             WHERE c.table_schema LIKE :database_name


### PR DESCRIPTION
### Motivation
- Prevent under-constrained `information_schema` joins from attributing foreign-key metadata belonging to other tables (that share a column name) to the current table, which could poison the Chain relationship graph and lead to incorrect relationship edges.

### Description
- Tightened the SQL in `Table::getTableDetails()` by adding `kcu.table_schema = c.table_schema` and `kcu.table_name = c.table_name` to the `LEFT JOIN` against `information_schema.key_column_usage` so FK metadata is matched to the same source table row as each `information_schema.columns` entry.

### Testing
- Attempted to run the focused tests `src/Rxn/Framework/Tests/Data/ChainTest.php` and `src/Rxn/Framework/Tests/Data/LinkTest.php`, but PHPUnit was not available in the environment so the automated tests could not be executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f584d7fd0c832fae4b708cf72c2ec7)