### PR TITLE
fix: avoid TypeError in CSRF token validation

### DIFF
--- a/src/Rxn/Framework/Http/Router/Session.php
+++ b/src/Rxn/Framework/Http/Router/Session.php
@@ -110,7 +110,7 @@ class Session extends Service
      * Verify a CSRF token from an incoming request against the
      * session. Uses a constant-time compare.
      */
-    public static function validateToken(string $submitted): bool
+    public static function validateToken($submitted): bool
     {
         if (empty($_SESSION['_csrf']) || !is_string($submitted)) {
             return false;

--- a/src/Rxn/Framework/Tests/Http/Router/SessionTokenTest.php
+++ b/src/Rxn/Framework/Tests/Http/Router/SessionTokenTest.php
@@ -37,4 +37,10 @@ final class SessionTokenTest extends TestCase
     {
         $this->assertFalse(Session::validateToken('whatever'));
     }
+
+    public function testValidateRejectsNonStringSubmittedToken(): void
+    {
+        Session::token();
+        $this->assertFalse(Session::validateToken(['token']));
+    }
 }


### PR DESCRIPTION
### Motivation
- `Session::validateToken()` declared its parameter as `string` which causes a `TypeError` when attacker-controlled request data (e.g. `_csrf[]` -> array) is passed, bypassing the intended runtime guard and crashing request handling.
- The framework catches only `\Exception` in legacy runner paths so a `TypeError` (an `Error`/`Throwable`) can escape and cause an unhandled fatal error affecting availability.

### Description
- Removed the `string` type hint from `Session::validateToken()` so non-string inputs reach the function body and are handled by the existing `is_string` guard (`public static function validateToken($submitted): bool`).
- Preserved the original validation behavior by keeping the `is_string` check and returning `false` for non-string submitted tokens.
- Added `SessionTokenTest::testValidateRejectsNonStringSubmittedToken()` which asserts that array input is rejected with `false` instead of causing a crash.

### Testing
- Added a unit test in `src/Rxn/Framework/Tests/Http/Router/SessionTokenTest.php` that verifies array input to `Session::validateToken()` returns `false`.
- Attempted to run `phpunit` but the `phpunit` binary is not available in this environment so the test could not be executed here.
- Attempted to run `./vendor/bin/phpunit` but the vendor PHPUnit binary is not present in this environment so automated test runs were not possible locally.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f584d7f63c832f94f20324901e24f7)