### PR TITLE
Canonicalize class names in Container to prevent case-variant cache growth

### DIFF
--- a/src/Rxn/Framework/Container.php
+++ b/src/Rxn/Framework/Container.php
@@ -151,6 +151,10 @@ class Container
             throw new ContainerException("$class_name is not a valid class name");
         }
 
+        // Canonicalise to the declared class casing so process-lifetime
+        // caches don't grow with case-variant aliases of the same class.
+        $class_name = $this->parseClassName(self::reflectionFor($class_name)->getName());
+
         // if we already stored an instance of a statically-bound service class, return it
         if (self::isService($class_name)
             && self::has($class_name)


### PR DESCRIPTION
### Motivation
- Long-running processes could be forced to populate the process-lifetime reflection and service caches with many attacker-controlled case-variant class-name strings, causing unbounded memory growth and potential OOM.
- The container previously keyed its static caches using the caller-supplied class string without canonicalizing to the declared class name, which allowed aliases that refer to the same loaded class to create duplicate entries.

### Description
- In `Container::get()` canonicalize the resolved class name using `ReflectionClass::getName()` and re-normalize with `parseClassName()` so cache keys use the declared class casing before any cache/service/instance operations.
- This change ensures `self::$reflectionCache` and `self::$isServiceCache` map case-variant aliases to the single canonical class key and prevents unbounded static cache growth.
- The modification is narrowly scoped to `src/Rxn/Framework/Container.php` and preserves the existing resolution, binding, and autowiring logic and fast paths.

### Testing
- Ran a syntax check with `php -l src/Rxn/Framework/Container.php`, which completed successfully.
- No other automated tests existed or were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f58b3de53c832f9d5426ed21b1593c)