### PR TITLE
fix(validator): sanitize compiled field comment text to prevent eval injection

### DIFF
--- a/src/Rxn/Framework/Tests/Utility/ValidatorTest.php
+++ b/src/Rxn/Framework/Tests/Utility/ValidatorTest.php
@@ -304,4 +304,19 @@ final class ValidatorTest extends TestCase
         $errors = Validator::check(['v' => '2026-04-29'], ['v' => ['date']]);
         $this->assertSame([], $errors);
     }
+    public function testCompileDoesNotExecuteInjectedFieldNameCode(): void
+    {
+        $tmp = sys_get_temp_dir() . '/rxn-validator-injection-' . uniqid('', true);
+        @unlink($tmp);
+
+        $field = "x\nfile_put_contents(" . var_export($tmp, true) . ", 'owned');\n//";
+        $rules = [$field => ['required']];
+
+        $check = Validator::compile($rules);
+        $errors = $check([]);
+
+        $this->assertArrayHasKey($field, $errors);
+        $this->assertFileDoesNotExist($tmp);
+    }
+
 }

--- a/src/Rxn/Framework/Utility/Validator.php
+++ b/src/Rxn/Framework/Utility/Validator.php
@@ -342,7 +342,7 @@ final class Validator
             $other[] = $rule;
         }
 
-        $src = "    // -- field: $field\n";
+        $src = "    /* field: " . self::quoteInlineComment($field) . " */\n";
         $src .= "    \$value = \$payload[$fieldQ] ?? null;\n";
         $src .= "    \$present = \\array_key_exists($fieldQ, \$payload) && \$value !== '' && \$value !== null;\n";
         $src .= "    if (!\$present) {\n";
@@ -516,6 +516,15 @@ final class Validator
         $patternQ = self::quoteString($arg);
         $msg     = self::quoteString("$field format is invalid");
         return "        if (!(\\is_string(\$value) && \\preg_match($patternQ, \$value) === 1)) { \$errors[$fieldQ][] = $msg; }\n";
+    }
+
+
+    /**
+     * Sanitize text embedded in generated one-line comments.
+     */
+    private static function quoteInlineComment(string $s): string
+    {
+        return str_replace(["\r", "\n", "*/"], [' ', ' ', '* /'], $s);
     }
 
     /**


### PR DESCRIPTION
### Motivation

- The compiled validator concatenates generated PHP and `eval()`s it, and raw rule field names were embedded into a `//` comment, allowing newline-driven code injection. 
- The fix prevents attacker-controlled field names from breaking out of the generated source and executing arbitrary PHP when `Validator::compile()` is used.

### Description

- Replace the raw `// -- field: $field` emission in `compileField()` with a sanitized inline block comment using `/* field: ... */` to avoid newline breakout; change located in `src/Rxn/Framework/Utility/Validator.php`.
- Add a helper `quoteInlineComment(string $s)` that neutralizes `\r`, `\n`, and `*/` sequences so embedded text cannot terminate or escape the generated comment.
- Update `compileField()` to call `self::quoteInlineComment($field)` when emitting the generated comment line.
- Add a regression test `testCompileDoesNotExecuteInjectedFieldNameCode` in `src/Rxn/Framework/Tests/Utility/ValidatorTest.php` that constructs a malicious field name, compiles the rules, invokes the compiled validator, and asserts that no injected side-effect file is created and the field is still reported as an error key.

### Testing

- Ran PHP syntax checks with `php -l` on `src/Rxn/Framework/Utility/Validator.php` and `src/Rxn/Framework/Tests/Utility/ValidatorTest.php`, and both files report no syntax errors.
- Added a unit regression test that verifies a malicious newline-containing field name does not execute injected PHP when the compiled closure is invoked; the test is present but the full test suite could not be executed in this environment because `vendor/bin/phpunit` is not available.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f58b3dacf8832f91702ae573992e80)