### PR TITLE
fix(container): remove unbounded parsed class-name cache

### DIFF
--- a/src/Rxn/Framework/Container.php
+++ b/src/Rxn/Framework/Container.php
@@ -63,16 +63,6 @@ class Container
     private static array $constructorPlanCache = [];
 
     /**
-     * Memoise normalised class names. parseClassName is a pure
-     * function (`'\\' . ltrim($input, '\\')`); same input always
-     * produces the same output, and it gets called multiple times
-     * per `get()` (entry call + recursive autowire + addInstance).
-     *
-     * @var array<string, string>
-     */
-    private static array $parsedNameCache = [];
-
-    /**
      * Precomputed normalised name of the Container class itself. Used
      * by `get()` to short-circuit when callers ask for the container.
      * Avoids a `ltrim($class_name, '\\') === ltrim(Container::class, '\\')`
@@ -336,12 +326,10 @@ class Container
         foreach ($constructor->getParameters() as $p) {
             $type = $p->getType();
             if ($type instanceof \ReflectionNamedType && !$type->isBuiltin()) {
-                // Pre-normalise the target FQCN so the recursive
-                // get($directive[1]) lands on the parseClassName cache
-                // immediately instead of paying for ltrim + concat.
+                // Pre-normalise the target FQCN so recursive
+                // get($directive[1]) skips repeated normalisation.
                 $name = $type->getName();
-                $normalised = self::$parsedNameCache[$name]
-                    ??= '\\' . ltrim($name, '\\');
+                $normalised = '\\' . ltrim($name, '\\');
                 $plan[] = ['autowire', $normalised];
                 continue;
             }
@@ -373,8 +361,7 @@ class Container
 
     private function parseClassName($class_name)
     {
-        return self::$parsedNameCache[$class_name]
-            ??= "\\" . ltrim($class_name, '\\');
+        return "\\" . ltrim($class_name, '\\');
     }
 
     /**


### PR DESCRIPTION
### Motivation
- Remove a process-lifetime memoization of normalized class names that could retain attacker-controlled, non-existent class names indefinitely and cause unbounded memory growth in long-lived PHP workers.

### Description
- Removed the `private static array $parsedNameCache` and eliminated reads/writes to that cache.
- Restored `parseClassName()` to a stateless normalization implemented as `"\\" . ltrim($class_name, '\\')`.
- Updated constructor-plan pre-normalization to compute normalized FQCNs inline using `"\\" . ltrim($name, '\\')` instead of consulting the removed cache.
- Preserved existing autowire, binding, and reflection caches and runtime behavior aside from removing the global parsed-name memoization.

### Testing
- Ran `php -l src/Rxn/Framework/Container.php` which reported no syntax errors.
- Attempted to run unit tests with `./vendor/bin/phpunit src/Rxn/Framework/Tests/ContainerTest.php` and `phpunit src/Rxn/Framework/Tests/ContainerTest.php`, but `phpunit` was not available in this environment so tests were not executed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f58b3da9ec832fbc7bb1ba389e5b33)