### PR TITLE
fix: invalidate query cache on write queries

### DIFF
--- a/src/Rxn/Framework/Data/Query.php
+++ b/src/Rxn/Framework/Data/Query.php
@@ -286,6 +286,9 @@ class Query
     {
         switch ($this->type) {
             case "query":
+                if ($this->caching) {
+                    $this->clearCache();
+                }
                 return true;
             case "fetchAll":
                 $result = $executed_statement->fetchAll(\PDO::FETCH_ASSOC);

--- a/src/Rxn/Framework/Tests/Data/QueryCacheTest.php
+++ b/src/Rxn/Framework/Tests/Data/QueryCacheTest.php
@@ -109,6 +109,25 @@ final class QueryCacheTest extends TestCase
         $this->assertSame([], glob($this->dir . '/*.qcache') ?: []);
     }
 
+    public function testWriteQueriesInvalidateExistingCachedReads(): void
+    {
+        $sql = 'SELECT v FROM kv WHERE k = :k';
+        $read = new Query($this->pdo, Query::TYPE_FETCH, $sql, ['k' => 'greeting']);
+        $read->setCache($this->dir, 60);
+        $this->assertSame(['v' => 'hello'], $read->run());
+        $this->assertCount(1, glob($this->dir . '/*.qcache') ?: []);
+
+        $write = new Query(
+            $this->pdo,
+            Query::TYPE_QUERY,
+            "UPDATE kv SET v = 'changed' WHERE k = 'greeting'"
+        );
+        $write->setCache($this->dir, 60);
+        $write->run();
+
+        $this->assertSame([], glob($this->dir . '/*.qcache') ?: []);
+    }
+
     public function testClearCacheRemovesAllEntries(): void
     {
         $sql = 'SELECT v FROM kv WHERE k = :k';


### PR DESCRIPTION
### Motivation
- Global filesystem query caching could return stale, security-sensitive read results (for example, revoked or expired auth tokens) because write queries did not invalidate previously cached reads.
- The change aims to prevent stale authorization decisions from persisting after state changes by ensuring writes clear the query cache when caching is enabled.

### Description
- Update `Query::returnQueryResults` so that `TYPE_QUERY` (write) statements call `clearCache()` when caching is enabled, ensuring cached read results are removed after writes.
- Add `testWriteQueriesInvalidateExistingCachedReads` to `src/Rxn/Framework/Tests/Data/QueryCacheTest.php` to assert that a prior cached read is removed when an update is executed.

### Testing
- Ran PHP syntax checks with `php -l` on `src/Rxn/Framework/Data/Query.php` and `src/Rxn/Framework/Tests/Data/QueryCacheTest.php`, both returned no syntax errors.
- Attempted to run `phpunit` but the `phpunit` binary was not available in the execution environment, so test suite execution could not be performed here.
- The new regression test is included and ready to run in CI or a local environment with `phpunit` present.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f584d81bc8832f999cb81bba585499)