### PR TITLE
fix: clear Psr15Pipeline per-run state to prevent stale handle bypass

### DIFF
--- a/src/Rxn/Framework/Http/Psr15Pipeline.php
+++ b/src/Rxn/Framework/Http/Psr15Pipeline.php
@@ -45,7 +45,13 @@ final class Psr15Pipeline implements RequestHandlerInterface
     {
         $this->terminal = $terminal;
         $this->index    = 0;
-        return $this->handle($request);
+
+        try {
+            return $this->handle($request);
+        } finally {
+            $this->terminal = null;
+            $this->index    = 0;
+        }
     }
 
     /**

--- a/src/Rxn/Framework/Tests/Http/Psr15PipelineTest.php
+++ b/src/Rxn/Framework/Tests/Http/Psr15PipelineTest.php
@@ -117,6 +117,15 @@ final class Psr15PipelineTest extends TestCase
         $this->assertFalse($terminalHit);
     }
 
+
+    public function testHandleAfterRunThrows(): void
+    {
+        $pipeline = new Psr15Pipeline();
+        $pipeline->run($this->request(), $this->terminal($this->response()));
+
+        $this->expectException(\LogicException::class);
+        $pipeline->handle($this->request());
+    }
     public function testHandleWithoutRunThrows(): void
     {
         $this->expectException(\LogicException::class);


### PR DESCRIPTION
### Motivation
- The PSR-15 pipeline stored per-request state (`$terminal` and `$index`) on the reusable pipeline object, allowing stale `handle()` calls after a previous `run()` to bypass earlier middleware and invoke the terminal directly. 
- This is dangerous in long-lived PHP processes or integrations that treat the pipeline as a `RequestHandlerInterface`, since it can lead to missing auth/rate-limit/CSRF middleware on subsequent requests.

### Description
- Ensure per-dispatch state is cleared by wrapping `run()` in a `try`/`finally` and resetting both `$terminal` and `$index` in the `finally` block. (change in `src/Rxn/Framework/Http/Psr15Pipeline.php`).
- Preserve existing middleware invocation semantics during an active dispatch so the chain behaves identically while `run()` is in progress.
- Add a regression test `testHandleAfterRunThrows()` to `src/Rxn/Framework/Tests/Http/Psr15PipelineTest.php` that verifies calling `handle()` after `run()` throws a `LogicException`.

### Testing
- Added unit test `testHandleAfterRunThrows()` in `src/Rxn/Framework/Tests/Http/Psr15PipelineTest.php` to prevent regression. 
- Attempted to run the tests with `vendor/bin/phpunit src/Rxn/Framework/Tests/Http/Psr15PipelineTest.php`, but execution was not possible in this environment because `vendor/bin/phpunit` is missing. 
- The change is minimal and covered by the new regression test to ensure stale `handle()` calls are rejected after a completed `run()`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f58c278a7c832fbc0bd40f08ce83b3)