### PR TITLE
fix: harden DTO binding and throwable error handling

### DIFF
--- a/src/Rxn/Framework/App.php
+++ b/src/Rxn/Framework/App.php
@@ -68,7 +68,7 @@ class App
     {
         try {
             $response = $this->dispatch();
-        } catch (\Exception $exception) {
+        } catch (\Throwable $exception) {
             $response = $this->renderFailure($exception);
         }
         self::render($response);
@@ -101,7 +101,7 @@ class App
         return $this->api->controller->trigger();
     }
 
-    private function renderFailure(\Exception $exception): Response
+    private function renderFailure(\Throwable $exception): Response
     {
         $response = $this->container->get(Response::class);
         if ($response->isRendered()) {

--- a/src/Rxn/Framework/Http/Binding/Binder.php
+++ b/src/Rxn/Framework/Http/Binding/Binder.php
@@ -67,6 +67,8 @@ final class Binder
                     $prop->setValue($dto, $prop->getDefaultValue());
                 } elseif ($type instanceof \ReflectionNamedType && $type->allowsNull()) {
                     $prop->setValue($dto, null);
+                } else {
+                    $errors[] = ['field' => $name, 'message' => 'is required'];
                 }
                 continue;
             }
@@ -88,7 +90,11 @@ final class Binder
                 }
             }
 
-            $prop->setValue($dto, $cast);
+            try {
+                $prop->setValue($dto, $cast);
+            } catch (\TypeError) {
+                $errors[] = ['field' => $name, 'message' => 'type mismatch'];
+            }
         }
 
         if ($errors !== []) {
@@ -499,8 +505,17 @@ final class Binder
      */
     private static function cast(mixed $value, ?\ReflectionType $type): mixed
     {
+        if ($type instanceof \ReflectionUnionType) {
+            foreach ($type->getTypes() as $unionType) {
+                $cast = self::cast($value, $unionType);
+                if ($cast !== self::CAST_FAIL) {
+                    return $cast;
+                }
+            }
+            return self::CAST_FAIL;
+        }
         if (!$type instanceof \ReflectionNamedType) {
-            return $value;
+            return self::CAST_FAIL;
         }
         $name = $type->getName();
 

--- a/src/Rxn/Framework/Http/Controller.php
+++ b/src/Rxn/Framework/Http/Controller.php
@@ -109,7 +109,7 @@ class Controller
             $this->calculateActionTimeElapsed($action_time_start);
             $this->validateActionResponse($action_response);
             return $this->response->getSuccess($action_response);
-        } catch (\Exception $exception) {
+        } catch (\Throwable $exception) {
             return $this->response->getFailure($exception);
         }
     }

--- a/src/Rxn/Framework/Http/Response.php
+++ b/src/Rxn/Framework/Http/Response.php
@@ -166,11 +166,11 @@ class Response
     }
 
     /**
-     * @param \Exception $exception
+     * @param \Throwable $exception
      *
      * @return Response
      */
-    public function getFailure(\Exception $exception): Response
+    public function getFailure(\Throwable $exception): Response
     {
         $this->setRendered(true);
 
@@ -216,11 +216,11 @@ class Response
     }
 
     /**
-     * @param \Exception $exception
+     * @param \Throwable $exception
      *
      * @return int|mixed|string
      */
-    public static function getErrorCode(\Exception $exception)
+    public static function getErrorCode(\Throwable $exception)
     {
         $code = $exception->getCode();
         if (empty($code)) {
@@ -230,11 +230,11 @@ class Response
     }
 
     /**
-     * @param \Exception $exception
+     * @param \Throwable $exception
      *
      * @return array
      */
-    public static function getErrorTrace(\Exception $exception)
+    public static function getErrorTrace(\Throwable $exception)
     {
         $full_trace         = $exception->getTrace();
         $allowed_debug_keys = [


### PR DESCRIPTION
### Motivation

- Requests with attacker-controlled DTO input could leave non-nullable, no-default public properties uninitialized, causing PHP `Error` when accessed instead of a validation failure.  
- Unsupported/reflection types (e.g. unions) could allow invalid values through to `ReflectionProperty::setValue()` and raise `TypeError`.  
- Controller/App only caught `\Exception`, so `Error`/`TypeError` could escape framework failure handling and crash requests (availability impact).

### Description

- `Binder::bind()` now records a validation error (`is required`) when a public property is omitted and is non-nullable with no default, preventing uninitialized property access.  
- `ReflectionProperty::setValue()` calls are wrapped in a `try/catch (TypeError)` and converted into a `type mismatch` validation error instead of letting the TypeError propagate.  
- `Binder::cast()` now handles `ReflectionUnionType` by attempting each arm and returning failure if none match, and returns `CAST_FAIL` for unsupported reflection types so invalid inputs become validation errors.  
- Controller and App error boundaries were hardened to catch `\Throwable` rather than `\Exception`, and `Response` failure helpers were updated to accept `\Throwable` so `Error`/`TypeError` are rendered via the framework failure response.

### Testing

- Attempted to run targeted PHPUnit suites (`src/Rxn/Framework/Tests/Http/Binding/BinderTest.php`, `ProblemDetailsIntegrationTest.php`, `ControllerTest.php`), but `vendor/bin/phpunit` is not available in this environment so automated tests could not be executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f593a571dc832fa2bda159244bb2b4)