### PR TITLE
Redact startup error internals in production

### DIFF
--- a/src/Rxn/Framework/App.php
+++ b/src/Rxn/Framework/App.php
@@ -166,16 +166,26 @@ class App
         }
         $response = new Response(null);
         $response->getFailure(new AppException('Environment errors on startup'));
-        $response->meta['startup_errors'] = self::$environment_errors;
+        $response->meta['startup_errors'] = self::isProductionEnvironment()
+            ? []
+            : self::$environment_errors;
         self::render($response);
     }
 
     public static function appendEnvironmentError(\Exception $exception): void
     {
-        self::$environment_errors[] = [
-            'file'    => $exception->getFile(),
-            'line'    => $exception->getLine(),
-            'message' => $exception->getMessage(),
-        ];
+        self::$environment_errors[] = self::isProductionEnvironment()
+            ? ['message' => 'Startup error']
+            : [
+                'file'    => $exception->getFile(),
+                'line'    => $exception->getLine(),
+                'message' => $exception->getMessage(),
+            ];
+    }
+
+    private static function isProductionEnvironment(): bool
+    {
+        return getenv('ENVIRONMENT') === 'production';
     }
 }
+

--- a/src/Rxn/Framework/Tests/AppErrorHandlingTest.php
+++ b/src/Rxn/Framework/Tests/AppErrorHandlingTest.php
@@ -1,0 +1,37 @@
+<?php declare(strict_types=1);
+
+namespace Rxn\Framework\Tests;
+
+use PHPUnit\Framework\TestCase;
+use ReflectionClass;
+use Rxn\Framework\App;
+
+final class AppErrorHandlingTest extends TestCase
+{
+    public function testRenderEnvironmentErrorsRedactsStartupErrorsInProduction(): void
+    {
+        $method = (new ReflectionClass(App::class))->getMethod('renderEnvironmentErrors');
+        $source = $this->extractMethodSource($method);
+
+        $this->assertStringContainsString('self::isProductionEnvironment()', $source);
+        $this->assertStringContainsString("? []", $source);
+    }
+
+    public function testAppendEnvironmentErrorDoesNotStoreFileLineInProduction(): void
+    {
+        $method = (new ReflectionClass(App::class))->getMethod('appendEnvironmentError');
+        $source = $this->extractMethodSource($method);
+
+        $this->assertStringContainsString("? ['message' => 'Startup error']", $source);
+        $this->assertStringContainsString("'file'    => $exception->getFile()", $source);
+        $this->assertStringContainsString("'line'    => $exception->getLine()", $source);
+    }
+
+    private function extractMethodSource(\ReflectionMethod $method): string
+    {
+        $file  = file($method->getFileName());
+        $start = $method->getStartLine() - 1;
+        $end   = $method->getEndLine();
+        return implode('', array_slice($file, $start, $end - $start));
+    }
+}


### PR DESCRIPTION
### Motivation
- The public bootstrap rendered startup exceptions and appended full exception `file`, `line`, and `message` into responses, exposing filesystem paths and stack details to unauthenticated clients in production.

### Description
- Change `App::renderEnvironmentErrors()` to set `meta.startup_errors` to an empty array when `ENVIRONMENT=production`, and retain detailed startup metadata for non-production environments.
- Change `App::appendEnvironmentError()` to push only a generic `['message' => 'Startup error']` entry in production while preserving `file`, `line`, and `message` in non-production environments.
- Add a private helper `App::isProductionEnvironment()` that returns `getenv('ENVIRONMENT') === 'production'` and use it to gate redaction.
- Add `src/Rxn/Framework/Tests/AppErrorHandlingTest.php` to assert presence of the production-redaction logic in `renderEnvironmentErrors` and `appendEnvironmentError`.

### Testing
- Attempted to run `vendor/bin/phpunit src/Rxn/Framework/Tests/Http/ResponseTest.php src/Rxn/Framework/Tests/AppErrorHandlingTest.php`, but test execution failed because `vendor/bin/phpunit` is not available in this environment (no PHPUnit installed).
- `phpunit --version` was also unavailable in the environment, so automated test execution could not be completed here; the added tests can be run in CI or a developer environment with PHPUnit installed using the same `vendor/bin/phpunit` command.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f584d78540832f86ea3948dbded5e0)