### PR TITLE
fix: remove environment disclosure from smoke endpoint

### DIFF
--- a/app/Http/Controller/v1/SmokeController.php
+++ b/app/Http/Controller/v1/SmokeController.php
@@ -13,8 +13,7 @@ class SmokeController extends \Rxn\Framework\Http\Controller
     public function ping_v1(): array
     {
         return [
-            'ok'  => true,
-            'env' => getenv('ENVIRONMENT') ?: 'unknown',
+            'ok' => true,
         ];
     }
 }


### PR DESCRIPTION
### Motivation
- Remove an operational information leak where the unauthenticated CI smoke endpoint returned `ENVIRONMENT`, preventing deployment-mode fingerprinting while preserving CI smoke behavior.

### Description
- Remove the `env` entry from the response in `app/Http/Controller/v1/SmokeController.php` so `ping_v1()` returns only `['ok' => true]`, leaving routing and CI assertions unchanged.

### Testing
- Ran `php -l app/Http/Controller/v1/SmokeController.php` which reported no syntax errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f5957bed90832f815ed0f523aa33d3)