### PR TITLE
Avoid caching mutable default objects in Container constructor plan

### DIFF
--- a/src/Rxn/Framework/Container.php
+++ b/src/Rxn/Framework/Container.php
@@ -50,7 +50,7 @@ class Container
     /**
      * Pre-computed construction recipe per class. Each entry is a
      * directive describing how to fill the corresponding constructor
-     * parameter slot — `['autowire', $class]`, `['default', $value]`,
+     * parameter slot — `['autowire', $class]`, `['default']`,
      * `['null']`, or `['fail', $param_name]`. `null` cache entry
      * means "no constructor; use newInstanceWithoutConstructor".
      *
@@ -58,7 +58,7 @@ class Container
      * Reflection*Parameter call after the first resolution, which
      * is where the bulk of the autowire cost lives.
      *
-     * @var array<string, list<array{0: string, 1?: mixed}>|null>
+     * @var array<string, list<array{0: string, 1?: string}>|null>
      */
     private static array $constructorPlanCache = [];
 
@@ -228,7 +228,8 @@ class Container
                     $create_parameters[$key] = $this->get($directive[1]);
                     break;
                 case 'default':
-                    $create_parameters[$key] = $directive[1];
+                    $constructor = self::reflectionFor($class_name)->getConstructor();
+                    $create_parameters[$key] = $constructor->getParameters()[$key]->getDefaultValue();
                     break;
                 case 'null':
                     $create_parameters[$key] = null;
@@ -281,8 +282,10 @@ class Container
                     $args[] = '$c->get(' . self::quoteString($directive[1]) . ')';
                     break;
                 case 'default':
-                    $args[] = var_export($directive[1], true);
-                    break;
+                    // Defaults can include object-creating expressions
+                    // (e.g. `= new Bag`) and must be evaluated per
+                    // constructor call. Fall back to runtime path.
+                    return null;
                 case 'null':
                     $args[] = 'null';
                     break;
@@ -338,7 +341,7 @@ class Container
                 continue;
             }
             if ($p->isDefaultValueAvailable()) {
-                $plan[] = ['default', $p->getDefaultValue()];
+                $plan[] = ['default'];
                 continue;
             }
             if ($p->allowsNull()) {

--- a/src/Rxn/Framework/Tests/ContainerTest.php
+++ b/src/Rxn/Framework/Tests/ContainerTest.php
@@ -4,13 +4,13 @@ namespace Rxn\Framework\Tests;
 
 use PHPUnit\Framework\TestCase;
 use Rxn\Framework\Container;
-use Rxn\Framework\Error\ContainerException;
 use Rxn\Framework\Tests\Fixture\Container\Clock;
 use Rxn\Framework\Tests\Fixture\Container\FrozenClock;
 use Rxn\Framework\Tests\Fixture\Container\SystemClock;
 use Rxn\Framework\Tests\Fixture\Container\Timestamper;
 use Rxn\Framework\Tests\Fixture\Container\UserRepo;
 use Rxn\Framework\Tests\Fixture\Container\MemoryUserRepo;
+use Rxn\Framework\Tests\Fixture\Container\NeedsDefaultBag;
 
 final class ContainerTest extends TestCase
 {
@@ -72,6 +72,18 @@ final class ContainerTest extends TestCase
         $c = new Container();
         $this->expectException(\Throwable::class);
         $c->get(UserRepo::class);
+    }
+
+
+    public function testDefaultObjectParameterIsNotSharedAcrossInstances(): void
+    {
+        $c = new Container();
+
+
+        $fromDefaultA = $c->get(NeedsDefaultBag::class);
+        $fromDefaultB = $c->get(NeedsDefaultBag::class);
+
+        $this->assertNotSame($fromDefaultA->bag, $fromDefaultB->bag);
     }
 
     public function testBindReturnsSelfForChaining(): void

--- a/src/Rxn/Framework/Tests/Fixture/Container/DefaultBag.php
+++ b/src/Rxn/Framework/Tests/Fixture/Container/DefaultBag.php
@@ -1,0 +1,9 @@
+<?php declare(strict_types=1);
+
+namespace Rxn\Framework\Tests\Fixture\Container;
+
+final class DefaultBag
+{
+    /** @var list<string> */
+    public array $items = [];
+}

--- a/src/Rxn/Framework/Tests/Fixture/Container/NeedsDefaultBag.php
+++ b/src/Rxn/Framework/Tests/Fixture/Container/NeedsDefaultBag.php
@@ -1,0 +1,8 @@
+<?php declare(strict_types=1);
+
+namespace Rxn\Framework\Tests\Fixture\Container;
+
+final class NeedsDefaultBag
+{
+    public function __construct(public object $bag = new DefaultBag) {}
+}


### PR DESCRIPTION
### Motivation
- The constructor plan cache stored concrete default parameter values (including objects created by `new` expressions) and therefore reused mutable defaults across multiple `get()` calls in long-lived processes, causing cross-request state leakage. 
- The change restores PHP semantics where `ReflectionParameter::getDefaultValue()` is evaluated per instantiation for defaults that can create objects. 

### Description
- Stop caching concrete default values: `constructorPlanFor()` now records `['default']` for parameters with a default instead of storing the actual value. 
- Evaluate defaults at instantiation time: `generateInstance()` calls the constructor parameter's `getDefaultValue()` for each `['default']` directive so each instance receives a fresh default object. 
- Prevent inlining defaults into compiled factories: `compileFactory()` returns `null` when a `default` directive is present so factories fall back to the runtime path and avoid embedding shared default values. 
- Add regression fixtures and a unit test (`DefaultBag`, `NeedsDefaultBag`, and `testDefaultObjectParameterIsNotSharedAcrossInstances`) to assert default object parameters are distinct across resolutions. 

### Testing
- Attempted to run the PHPUnit subset via `vendor/bin/phpunit src/Rxn/Framework/Tests/ContainerTest.php`, but the `phpunit` binary is not available in this environment so the run failed. 
- Attempted `composer test`, but it also failed because the `phpunit` executable was not found in the environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f5964e7fa8832fbe98e79254666908)