### PR TITLE
Fix missing runtime PDO requirement after rxn-orm demotion

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,6 +18,7 @@
   ],
   "require": {
     "php": "^8.2",
+    "ext-pdo": "*",
     "vlucas/phpdotenv": "^3.0",
     "nyholm/psr7": "^1.8",
     "nyholm/psr7-server": "^1.1",
@@ -28,8 +29,8 @@
     "davidwyly/rxn-orm": "^0.1"
   },
   "suggest": {
-    "davidwyly/rxn-orm": "^0.1 — Rxn's query builder + ActiveRecord-shaped layer. Required only when you use `Rxn\\Framework\\Data\\Database::run()` or `Rxn\\Framework\\Model\\ActiveRecord` (and the `bin/bench` builder cases). Apps using Rxn purely for routing / DTO binding / middleware don't need this — install it when you reach for the Data / Model layer.",
-    "psr/simple-cache": "^3.0 — required only when using `Psr16IdempotencyStore` to plug an existing PSR-16 cache (Redis / Memcached / APCu) into the Idempotency middleware. Apps using `FileIdempotencyStore` (the default) don't need this."
+    "davidwyly/rxn-orm": "^0.1 \u2014 Rxn's query builder + ActiveRecord-shaped layer. Required only when you use `Rxn\\Framework\\Data\\Database::run()` or `Rxn\\Framework\\Model\\ActiveRecord` (and the `bin/bench` builder cases). Apps using Rxn purely for routing / DTO binding / middleware don't need this \u2014 install it when you reach for the Data / Model layer.",
+    "psr/simple-cache": "^3.0 \u2014 required only when using `Psr16IdempotencyStore` to plug an existing PSR-16 cache (Redis / Memcached / APCu) into the Idempotency middleware. Apps using `FileIdempotencyStore` (the default) don't need this."
   },
   "scripts": {
     "test": "phpunit"


### PR DESCRIPTION
### Motivation
- `davidwyly/rxn-orm` was moved out of runtime requirements into `require-dev`/`suggest`, but runtime code still type-hints/instantiates `\PDO`, so an explicit `ext-pdo` platform requirement is needed to avoid downstream runtime failures.

### Description
- Add `"ext-pdo": "*"` to the `require` block in `composer.json` to restore an explicit runtime PDO requirement while leaving `davidwyly/rxn-orm` in `require-dev` and `suggest` as intended.

### Testing
- Ran `composer validate --strict` which reported the lockfile is out of date after the `composer.json` change, and attempted `composer update --lock --no-install` which failed due to network access to GitHub (curl 403), preventing lock regeneration in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f5964ddb44832f84988879e34a2fa9)