### PR TITLE
fix(container): avoid eval factory for object default constructor values

### DIFF
--- a/src/Rxn/Framework/Container.php
+++ b/src/Rxn/Framework/Container.php
@@ -281,6 +281,12 @@ class Container
                     $args[] = '$c->get(' . self::quoteString($directive[1]) . ')';
                     break;
                 case 'default':
+                    // var_export(object) emits `Class::__set_state(...)`,
+                    // which is not equivalent to runtime default values and
+                    // can fatal for classes that don't implement it.
+                    if (is_object($directive[1])) {
+                        return null;
+                    }
                     $args[] = var_export($directive[1], true);
                     break;
                 case 'null':


### PR DESCRIPTION
### Motivation

- The compiled fast-path factories emitted `var_export()` for constructor default values which turns object defaults into `Class::__set_state(...)` calls and can fatal for classes that don't implement `__set_state()`. 
- The behavior diverged from the runtime slow path which preserves actual default objects (e.g. PHP 8.1+ object defaults), causing container resolution crashes.

### Description

- Added an `is_object()` check inside `compileFactory()` so that when a constructor default is an object the method returns `null` to disable the eval-compiled factory and fall back to the runtime path. 
- Preserved existing behavior for non-object defaults and left the runtime walker and exception messages unchanged. 
- The change is limited to `src/Rxn/Framework/Container.php` and only affects factory compilation when object defaults are present.

### Testing

- Ran `php -l src/Rxn/Framework/Container.php` and it reported no syntax errors. 
- Attempted `vendor/bin/phpunit` but the test runner is not available in this environment so full suite could not be executed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f5964eb968832fbe60e245129282e4)