### PR TITLE
fix: clear request headers between TestClient requests

### DIFF
--- a/src/Rxn/Framework/Testing/TestClient.php
+++ b/src/Rxn/Framework/Testing/TestClient.php
@@ -130,6 +130,8 @@ final class TestClient
     {
         [$pathOnly, $query] = self::splitPath($path);
 
+        $this->clearRequestServerHeaders();
+
         $_SERVER['REQUEST_METHOD'] = $method;
         $_SERVER['REQUEST_URI']    = $path;
         $_GET                      = $query;
@@ -145,6 +147,18 @@ final class TestClient
                 $_SERVER['CONTENT_LENGTH'] = $value;
             }
         }
+    }
+
+
+    private function clearRequestServerHeaders(): void
+    {
+        foreach (array_keys($_SERVER) as $key) {
+            if (str_starts_with($key, 'HTTP_')) {
+                unset($_SERVER[$key]);
+            }
+        }
+
+        unset($_SERVER['CONTENT_TYPE'], $_SERVER['CONTENT_LENGTH']);
     }
 
     /** @return array{0: string, 1: array<string, string>} */

--- a/src/Rxn/Framework/Tests/Testing/TestClientTest.php
+++ b/src/Rxn/Framework/Tests/Testing/TestClientTest.php
@@ -125,6 +125,39 @@ final class TestClientTest extends TestCase
         $this->assertSame('Bearer xyz', $seen);
     }
 
+
+    public function testRequestHeadersDoNotLeakBetweenRequests(): void
+    {
+        $router = new Router();
+        $router->get('/h', ['h']);
+        $seen = [];
+
+        $client = new TestClient($router, function () use (&$seen) {
+            $seen[] = [
+                'authorization' => $_SERVER['HTTP_AUTHORIZATION'] ?? null,
+                'content_type' => $_SERVER['CONTENT_TYPE'] ?? null,
+                'content_length' => $_SERVER['CONTENT_LENGTH'] ?? null,
+            ];
+            return (new Response())->getSuccess([]);
+        });
+
+        $client->get('/h', [
+            'Authorization' => 'Bearer xyz',
+            'Content-Type' => 'application/json',
+            'Content-Length' => '3',
+        ])->assertOk();
+
+        $client->get('/h')->assertOk();
+
+        $this->assertSame('Bearer xyz', $seen[0]['authorization']);
+        $this->assertSame('application/json', $seen[0]['content_type']);
+        $this->assertSame('3', $seen[0]['content_length']);
+
+        $this->assertNull($seen[1]['authorization']);
+        $this->assertNull($seen[1]['content_type']);
+        $this->assertNull($seen[1]['content_length']);
+    }
+
     public function testQueryStringIsParsedIntoGet(): void
     {
         $router = new Router();


### PR DESCRIPTION
### Motivation
- The in-process `TestClient` was leaving request-derived `$_SERVER` keys (e.g. `HTTP_AUTHORIZATION`, `CONTENT_TYPE`, `CONTENT_LENGTH`) set across simulated requests, causing cross-request state leakage and misleading test outcomes. 
- Tests that rely on header absence (authentication, content-type checks) could be falsely satisfied by stale values from a prior request, so request isolation needed to be enforced.

### Description
- Add a new `clearRequestServerHeaders()` helper to `TestClient` that removes existing `HTTP_*` entries and unsets `CONTENT_TYPE` and `CONTENT_LENGTH` from `$_SERVER`.
- Call `clearRequestServerHeaders()` at the start of `populateSuperglobals()` so each simulated request starts with a clean server header state before populating the new request.
- Add a regression test `testRequestHeadersDoNotLeakBetweenRequests()` to `TestClientTest` that sends one request with headers and a second without, and asserts the second request sees `null` for the authorization/content headers.

### Testing
- Ran `php -l` on `src/Rxn/Framework/Testing/TestClient.php` and `src/Rxn/Framework/Tests/Testing/TestClientTest.php`, and both files report no syntax errors. 
- Added an automated regression test `testRequestHeadersDoNotLeakBetweenRequests()` to validate header isolation across requests. 
- Attempted to run the test suite with `phpunit` but `phpunit` is not available in this environment, so full test execution could not be performed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f5964d7798832fbd3827303221b026)