### PR TITLE
fix: keep migrate:status read-only

### DIFF
--- a/bin/rxn
+++ b/bin/rxn
@@ -144,7 +144,7 @@ try {
 
         case 'migrate:status':
             $database  = rxn_make_database($projectRoot);
-            $migration = new Data\Migration($database, rxn_migration_dir($projectRoot));
+            $migration = new Data\Migration($database, rxn_migration_dir($projectRoot), false);
             $applied   = $migration->applied();
             $available = $migration->available();
             $pending   = array_values(array_diff($available, $applied));

--- a/src/Rxn/Framework/Data/Migration.php
+++ b/src/Rxn/Framework/Data/Migration.php
@@ -28,14 +28,16 @@ class Migration
      */
     private $directory;
 
-    public function __construct(Database $database, string $directory)
+    public function __construct(Database $database, string $directory, bool $ensureTable = true)
     {
         if (!is_dir($directory)) {
             throw new DatabaseException("Migration directory does not exist: $directory", 500);
         }
         $this->database  = $database;
         $this->directory = rtrim($directory, '/');
-        $this->ensureTable();
+        if ($ensureTable) {
+            $this->ensureTable();
+        }
     }
 
     /**
@@ -63,7 +65,14 @@ class Migration
      */
     public function applied(): array
     {
-        $rows = $this->database->fetchAll("SELECT filename FROM `" . self::TABLE . "` ORDER BY filename ASC");
+        try {
+            $rows = $this->database->fetchAll("SELECT filename FROM `" . self::TABLE . "` ORDER BY filename ASC");
+        } catch (\PDOException $exception) {
+            if ((int)$exception->getCode() === 1146) {
+                return [];
+            }
+            throw $exception;
+        }
         return array_column($rows ?: [], 'filename');
     }
 


### PR DESCRIPTION
### Motivation
- The `migrate:status` command is documented to list applied and pending migrations “without touching the schema”, but constructing `Data\Migration` unconditionally ran `ensureTable()` which executed `CREATE TABLE IF NOT EXISTS` and caused unexpected schema writes or failures against read-only DB accounts.
- The change preserves the read-only semantics of `migrate:status` and avoids surprising side effects when operators query migration status.

### Description
- Instantiate `Data\Migration` with table initialization disabled on the `migrate:status` path by passing `false` for a new constructor flag in `bin/rxn` (status-only path now calls `new Data\Migration(..., false)`).
- Add an optional `bool $ensureTable = true` parameter to `Rxn\Framework\Data\Migration::__construct()` and only call `ensureTable()` when it is true so normal `migrate` behavior is unchanged.
- Make `Migration::applied()` catch `\PDOException` with code `1146` (table does not exist) and return an empty array so a status query remains functional on fresh or read-only databases without attempting schema writes.

### Testing
- Attempted to run `vendor/bin/phpunit src/Rxn/Framework/Tests/Data/MigrationDiscoveryTest.php src/Rxn/Framework/Tests/CliTest.php` but the PHPUnit binary is not present in this checkout so the automated test run could not be executed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f5964e23f8832f89f0281b462ace95)