### PR TITLE
Sanitize production throwable messages in failure responses

### DIFF
--- a/src/Rxn/Framework/Http/Response.php
+++ b/src/Rxn/Framework/Http/Response.php
@@ -3,6 +3,7 @@
 namespace Rxn\Framework\Http;
 
 use \Rxn\Framework\App;
+use \Rxn\Framework\Error\RequestException;
 use \Rxn\Framework\Http\Binding\ValidationException;
 
 /**
@@ -170,7 +171,7 @@ class Response
         $this->code   = (int)$code;
         $this->errors = [
             'type'    => self::getResponseCodeResult($code),
-            'message' => $exception->getMessage(),
+            'message' => self::getPublicErrorMessage($exception),
         ];
         if ($exception instanceof ValidationException) {
             $this->validation_errors = $exception->errors();
@@ -189,6 +190,24 @@ class Response
         ];
 
         return $this;
+    }
+
+
+    /**
+     * Keep explicit client-facing request errors verbatim, but hide
+     * internal Throwable detail in production.
+     */
+    private static function getPublicErrorMessage(\Throwable $exception): string
+    {
+        if (getenv('ENVIRONMENT') !== 'production') {
+            return $exception->getMessage();
+        }
+
+        if ($exception instanceof RequestException) {
+            return $exception->getMessage();
+        }
+
+        return self::getResponseCodeResult(self::getErrorCode($exception));
     }
 
     /**

--- a/src/Rxn/Framework/Tests/Http/ResponseTest.php
+++ b/src/Rxn/Framework/Tests/Http/ResponseTest.php
@@ -107,10 +107,23 @@ final class ResponseTest extends TestCase
             $this->assertSame('about:blank', $pd['type']);
             $this->assertSame('Not Found', $pd['title']);
             $this->assertSame(404, $pd['status']);
-            $this->assertSame('row not found', $pd['detail']);
+            $this->assertSame('Not Found', $pd['detail']);
             $this->assertSame('/users/42', $pd['instance']);
         } finally {
             putenv('ENVIRONMENT');
+        }
+    }
+
+    public function testGetFailureKeepsRequestExceptionMessageInProduction(): void
+    {
+        $previous = getenv('ENVIRONMENT');
+        putenv('ENVIRONMENT=production');
+        try {
+            $response = new Response();
+            $response->getFailure(new \Rxn\Framework\Error\RequestException('bad request', 400));
+            $this->assertSame('bad request', $response->getErrors()['message']);
+        } finally {
+            putenv($previous !== false ? "ENVIRONMENT=$previous" : 'ENVIRONMENT');
         }
     }
 


### PR DESCRIPTION
### Motivation
- Top-level handlers now catch `Throwable` (engine errors like `TypeError`) and these messages were being serialized verbatim into Problem Details responses in production, leaking internal implementation details.
- Production responses should expose explicit client-facing errors (request/validation failures) but not internal engine or runtime details.

### Description
- Replace direct use of `Throwable::getMessage()` in `Response::getFailure()` with a helper `getPublicErrorMessage()` that returns the raw message only when `ENVIRONMENT` is not `production` or when the throwable is a `RequestException` (and thus intentionally client-facing). 
- Add `use \Rxn\Framework\Error\RequestException;` and the helper `private static function getPublicErrorMessage(\Throwable $exception): string` in `src/Rxn/Framework/Http/Response.php` to map non-request throwables to status-text detail in production.
- Update `src/Rxn/Framework/Tests/Http/ResponseTest.php` to expect a generic detail (status text) for non-request exceptions in production and add `testGetFailureKeepsRequestExceptionMessageInProduction()` to assert that `RequestException` messages are preserved.

### Testing
- Ran syntax checks via `php -l` on `src/Rxn/Framework/Http/Response.php` and `src/Rxn/Framework/Tests/Http/ResponseTest.php`, both of which reported no syntax errors.
- Updated unit test expectations in `ResponseTest` and added a new test asserting `RequestException` behavior; running the test suite with `vendor/bin/phpunit` was attempted but the `phpunit` binary is not available in this environment so full test execution could not be performed.
- Confirmed local edits compile and the changed tests are syntactically valid.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f6539aa53c832fad756bd6bd501bc5)