### PR TITLE
docs: reconcile README + CHANGELOG against current master + fix TestClientTest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 # Changelog
 
-All notable changes to Rxn between releases. Unreleased work lives
-on `claude/code-review-pDtRd` until cut to a tagged version.
+All notable changes to Rxn between releases. Unreleased work lands
+on short-lived `experiment/*` branches and merges to `master` via
+PR; the next tagged version cuts from `master`.
 
 The format roughly follows [Keep a Changelog](https://keepachangelog.com)
 with one Rxn-specific section: **Negative results.** Performance
@@ -11,7 +12,91 @@ read alongside the wins.
 
 ## Unreleased
 
-### PSR refactor (`experiment/psr-7-refactor`)
+### Cross-language compiled validator (`experiment/cross-lang-validator`, PR #14)
+
+A PHP `RequestDto` compiles to a vanilla ES module that agrees
+with `Binder::bind` on the set of failing fields for **0
+disagreements over 10,000 random adversarial inputs** across four
+fixture DTOs (40,000 inputs / CI run). Useful for PHP shops with
+a TypeScript or vanilla-JS frontend that want drift-free
+validation across the wire.
+
+#### Added
+
+- **`Rxn\Framework\Codegen\JsValidatorEmitter`** — `emit(string
+  $class): string` returns a self-contained ES module mirroring
+  `Binder::compileProperty()` line-for-line in JavaScript.
+  Coverage: `Required`, `NotBlank`, `Length`, `Min`, `Max`,
+  `InSet`, `Email`, `Url` plus the four scalar casts (string, int,
+  float, bool). The PHP int round-trip guard
+  (`is_numeric($v) && (string)(int)$v === (string)$v`) is mirrored
+  bit-for-bit.
+- **`Rxn\Framework\Codegen\Testing\ParityHarness`** — generic
+  cross-runtime parity harness. `ParityHarness::run($dto, $source,
+  $invoke, $iterations)` returns a `ParityResult` with disagreements
+  + samples; `ParityHarness::nodeInvoker()` is the standard
+  NDJSON-driven Node invocation.
+- **`AdversarialInputGenerator`** — DTO-driven random input
+  generator. Reflects properties + attributes; emits omissions,
+  type mismatches, boundary violations, InSet drift, malformed
+  Email/Url fixtures. 20% omit / 8% null / 4% empty string by
+  default.
+- **`Rxn\Framework\Codegen\Testing\ParityResult`** — outcome
+  value object with `describe()` for failure-message formatting.
+- **Refusal-on-unknown-attribute.** Emitter throws
+  `RuntimeException` for `Pattern`, `Uuid`, `Json`, `Date`,
+  `StartsWith`, `EndsWith` and custom `Validates` implementations.
+  Each has a known PHP/JS runtime divergence (PCRE vs JS regex,
+  parser-shape differences); silent divergence is the worst
+  failure mode, so the emitter doesn't try.
+
+#### Tests
+
+- `JsValidatorParityTest` — DataProvider over four fixture DTOs ×
+  10K iterations = **40K cross-runtime inputs per CI run**.
+  Skipped automatically when `node` isn't on PATH.
+- `JsValidatorEdgeCaseTest` — 30 hand-picked tricky inputs.
+  Caught a real PHP/JS divergence at `"  42"` for an int field
+  (PHP rejected via round-trip; JS had a leading `.trim()` that
+  let it through). Fixed by removing the trim — the edge-case
+  test caught what 10K random inputs missed.
+
+#### Docs
+
+- `docs/plugin-architecture.md` — what lives in core vs. as
+  separate Composer packages. Honest minimal scope: only
+  `davidwyly/rxn-orm` is currently extracted; no formal plugin
+  contract until there are enough plugins to justify one.
+  Documents the rolled-back cross-language ambition (audience
+  mismatch + wrong vehicle) explicitly.
+- `bench/ab/experiments/2026-05-01-cross-lang-validator.md` —
+  full writeup, coverage matrix, and the rolled-back framing.
+
+### Fiber-aware in-request parallelism (`experiment/fiber-await`, PR #8)
+
+Opt-in concurrency primitives for fan-out scenarios (dashboards,
+aggregations). Sync-first posture preserved — Fibers are an
+explicit per-handler choice, not a framework-wide rewrite.
+
+#### Added
+
+- **`Rxn\Framework\Concurrency\Scheduler`** — Fiber scheduler
+  with `await(Promise)` / `awaitAll([Promise])` / `awaitAny([Promise])`.
+- **`Rxn\Framework\Concurrency\Promise`** — Fiber-aware promise
+  primitive backed by `curl_multi` for HTTP fan-out.
+- **`Rxn\Framework\Concurrency\HttpClient`** — Fiber-friendly
+  HTTP client (`get`, `post`) returning `Promise`.
+- **`Rxn\Framework\Concurrency\await.php`** — function-level
+  helpers (`await`, `awaitAll`, `awaitAny`) for handler code.
+- **`docs/horizons.md`** — research-directions roadmap. Four
+  directions sized with cost / mechanism / ship signal: schema
+  as truth taken further, observability ships in the box,
+  fiber-aware concurrency (this experiment), profile-guided
+  compilation.
+- **Example app `/dashboard` route** — fan-out demo using three
+  parallel HTTP calls via `awaitAll`.
+
+
 
 Five PSR specs landed end-to-end across the dispatch spine, plus
 two structural refactors and an opt-in on-disk dump cache. Every

--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ Opinionated pieces worth naming:
 
 ### Simplicity
 
-Small enough to read end to end — **~11K LOC of framework code
+Small enough to read end to end — **~12K LOC of framework code
 ships what a comparably-featured Slim or Mezzio composition
 reaches in 70–100K LOC of vendor packages** (DTO binding +
 attribute-driven validation, OpenAPI from reflection, idempotency
@@ -212,7 +212,7 @@ cumulative scoreboard is in
 
 ```bash
 composer install
-vendor/bin/phpunit          # 483 tests, 1048 assertions
+vendor/bin/phpunit          # 554 tests, 1145 assertions
 bin/rxn help                # CLI subcommands
 ```
 
@@ -293,7 +293,7 @@ end-to-end HTTP smoke job against MySQL 8
 
 Test counts:
 
-- **Rxn framework:** 483 tests / 1048 assertions (`vendor/bin/phpunit`).
+- **Rxn framework:** 554 tests / 1145 assertions (`vendor/bin/phpunit`).
 - **[`davidwyly/rxn-orm`](https://github.com/davidwyly/rxn-orm)**
   (query builder): 68 tests / 132 assertions, run in that repo.
 
@@ -315,7 +315,9 @@ methodology is in
 | Scaffolded CRUD | [`docs/scaffolding.md`](docs/scaffolding.md) |
 | Error handling | [`docs/error-handling.md`](docs/error-handling.md) |
 | Building blocks (Logger, RateLimiter, Scheduler, Auth, Pipeline, Router, Validator, Migration, Chain, query cache, PSR-7 bridge) | [`docs/building-blocks.md`](docs/building-blocks.md) |
-| PSR-7 / PSR-15 interop — why the framework is bridged not native, and when each stack applies | [`docs/psr-7-interop.md`](docs/psr-7-interop.md) |
+| PSR-7 / PSR-15 interop — bench evidence behind the ingress cost analysis (page predates the PSR-15 native migration; see CHANGELOG) | [`docs/psr-7-interop.md`](docs/psr-7-interop.md) |
+| Plugin architecture — what lives in core vs. as separate Composer packages | [`docs/plugin-architecture.md`](docs/plugin-architecture.md) |
+| Horizons — research directions that could reposition the framework, each sized with cost and ship signal | [`docs/horizons.md`](docs/horizons.md) |
 | CLI (`bin/rxn`) | [`docs/cli.md`](docs/cli.md) |
 | Benchmarks (`bin/bench`) | [`docs/benchmarks.md`](docs/benchmarks.md) |
 | Cross-framework comparison (Slim / Symfony / raw) | [`bench/compare/README.md`](bench/compare/README.md) |

--- a/README.md
+++ b/README.md
@@ -212,7 +212,7 @@ cumulative scoreboard is in
 
 ```bash
 composer install
-vendor/bin/phpunit          # 554 tests, 1145 assertions
+vendor/bin/phpunit          # 560 tests, 1159 assertions
 bin/rxn help                # CLI subcommands
 ```
 
@@ -293,7 +293,7 @@ end-to-end HTTP smoke job against MySQL 8
 
 Test counts:
 
-- **Rxn framework:** 554 tests / 1145 assertions (`vendor/bin/phpunit`).
+- **Rxn framework:** 560 tests / 1159 assertions (`vendor/bin/phpunit`).
 - **[`davidwyly/rxn-orm`](https://github.com/davidwyly/rxn-orm)**
   (query builder): 68 tests / 132 assertions, run in that repo.
 

--- a/docs/design-philosophy.md
+++ b/docs/design-philosophy.md
@@ -225,7 +225,7 @@ to read is slow to *develop in*. Time-to-first-bug-fixed is a
 real metric.
 
 Rxn fits in your head:
-- The framework is ~10k LOC of PHP excluding tests; the dispatch
+- The framework is ~12k LOC of PHP excluding tests; the dispatch
   spine — Container, Router, Pipeline, Binder, Validator,
   Request, Response — is ~3k of that, readable in one sitting.
   Middlewares, OpenAPI, scaffolding, and the legacy ActiveRecord
@@ -356,7 +356,7 @@ principles are how we keep the substrate healthy.
 | 5 — convention + escape hatch | `App::run` convention router → `Http\Router` explicit; `Container` autowire → `bind()` |
 | 6 — measure to commit | `bench/ab.php` driver, 16 experiment writeups, 4 negative-result branches preserved on origin |
 | 7 — transparent vs visible opt-in | Container's 5 stacked caches: zero API change. `Validator::compile`: visible because of the FPM tradeoff |
-| 8 — smallness as constraint | ~10k LOC framework, ~3k LOC dispatch spine (Container, Router, Pipeline, Binder, Validator, Request, Response) — readable in one sitting; the rest is opt-in subsystems |
+| 8 — smallness as constraint | ~12k LOC framework, ~3k LOC dispatch spine (Container, Router, Pipeline, Binder, Validator, Request, Response) — readable in one sitting; the rest is opt-in subsystems |
 | 9 — ergonomics are performance | `bin/preload.php`, `bench/ab/CONSOLIDATION.md`, `docs/index.md`'s topic table |
 | 10 — honesty | "alpha" status in README, `App::run` open-bugs note in `docs/benchmarks.md`, the long-lived-worker caveat in every compile-path docstring |
 | 11 — optional deps via lazy autoload | `Psr16IdempotencyStore` (typehints `\Psr\SimpleCache\CacheInterface`) and `Database::run()` / `ActiveRecord` (typehint `\Rxn\Orm\Builder\Buildable` / `Query`); both packages live in `composer.json`'s `suggest` block, framework loads cleanly without them |

--- a/src/Rxn/Framework/Tests/Testing/TestClientTest.php
+++ b/src/Rxn/Framework/Tests/Testing/TestClientTest.php
@@ -159,13 +159,13 @@ final class TestClientTest extends TestCase
         $router->get('/h', ['h']);
         $seen = [];
 
-        $client = new TestClient($router, function () use (&$seen) {
+        $client = new TestClient($router, function () use (&$seen): ResponseInterface {
             $seen[] = [
                 'authorization' => $_SERVER['HTTP_AUTHORIZATION'] ?? null,
                 'content_type' => $_SERVER['CONTENT_TYPE'] ?? null,
                 'content_length' => $_SERVER['CONTENT_LENGTH'] ?? null,
             ];
-            return (new Response())->getSuccess([]);
+            return self::ok([]);
         });
 
         $client->get('/h', [


### PR DESCRIPTION
## Summary

- Fixes a broken test introduced by #35 (`testRequestHeadersDoNotLeakBetweenRequests` returned `(new Response())->getSuccess([])`, but `Response` was unimported and isn't `ResponseInterface` — `TestClient`'s dispatcher contract requires PSR-7). Replaced with `self::ok([])`, the helper every other test in the file uses.
- Reconciles README, CHANGELOG, and design-philosophy against what's actually on master after #7 / #8 / #14:
  - Test counts (483/1048 → **560/1159**) in two places
  - Framework LOC (~11K → **~12K**, measured 12,487) in three places
  - PSR-7 interop docs table entry softened (the page predates the PSR-15 native migration, as the page itself acknowledges)
  - README docs table now lists `plugin-architecture.md` and `horizons.md`
  - CHANGELOG header replaced its stale `claude/code-review-pDtRd` branch reference with the actual PR-to-master flow
  - CHANGELOG Unreleased gains entries for **PR #14** (cross-language compiled validator + ParityHarness + AdversarialInputGenerator) and **PR #8** (fiber-aware in-request parallelism via Concurrency\{Scheduler, Promise, HttpClient} + horizons.md) — both shipped to master but were undocumented

## Test plan

- [x] `vendor/bin/phpunit` — 560 tests / 1159 assertions, all green
- [x] No code paths touched outside the one-line test fix; doc edits only otherwise
- [x] No backwards-compatibility concerns