### PR TITLE
feat(Codegen): PolyparityExporter — DTO to polyparity YAML bridge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,28 @@ read alongside the wins.
 
 ## Unreleased
 
+### Polyparity exporter (`feature/polyparity-exporter`)
+
+#### Added
+
+- **`Rxn\Framework\Codegen\PolyparityExporter`** — emits a
+  [polyparity](https://github.com/davidwyly/polyparity) YAML
+  spec from any `RequestDto`. Same coverage matrix as
+  `JsValidatorEmitter` (Required, NotBlank, Length, Min, Max,
+  InSet, Email, Url + scalar types), same refusal on out-of-
+  scope attributes. The bridge that lets one DTO drive Rxn's
+  PHP server, the JS twin, AND polyparity's TS / Python /
+  future-language siblings.
+- `PolyparityExporterTest` — snapshot tests for `ParityDto`,
+  `KitchenSinkDto`, `NumericEdgeDto`. Refusal test for
+  `UnsupportedDto` (uses `#[Pattern]`).
+- Verified end-to-end: a smoke test ran the exporter's YAML
+  through `polyparity-php`'s `Validator::compile()` and
+  confirmed the seven exercised cases (valid full payload,
+  missing required, invalid InSet, invalid Length, invalid
+  url, invalid email, int round-trip rejection) match the
+  expected polyparity verdicts.
+
 ### Cross-language compiled validator (`experiment/cross-lang-validator`, PR #14)
 
 A PHP `RequestDto` compiles to a vanilla ES module that agrees

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "08a830abb6f431b270ff90dcb873e53d",
+    "content-hash": "ca59634b4bdac3912fc6bc7ebdebafa9",
     "packages": [
         {
             "name": "nyholm/psr7",

--- a/docs/plugin-architecture.md
+++ b/docs/plugin-architecture.md
@@ -27,6 +27,14 @@ contract to be useful. When there are, this doc grows.
   test rig that the JS validator's correctness rests on
   (runs adversarial inputs through PHP and the emitted JS,
   asserts agreement on the failing-field set per input).
+- `Rxn\Framework\Codegen\PolyparityExporter` — emits a
+  [polyparity](https://github.com/davidwyly/polyparity) YAML
+  spec from any `RequestDto`. Bridge for PHP shops with
+  polyglot frontends: the same DTO drives Rxn's PHP server,
+  the JS twin via `JsValidatorEmitter`, AND a polyparity spec
+  that polyparity's TS / Python / future-language siblings
+  consume. Same coverage matrix as the JS emitter, same
+  refusal posture on out-of-scope attributes.
 
 **Outside core (separate Composer packages):**
 

--- a/src/Rxn/Framework/Codegen/PolyparityExporter.php
+++ b/src/Rxn/Framework/Codegen/PolyparityExporter.php
@@ -1,0 +1,239 @@
+<?php declare(strict_types=1);
+
+namespace Rxn\Framework\Codegen;
+
+use Rxn\Framework\Http\Attribute\Email;
+use Rxn\Framework\Http\Attribute\InSet;
+use Rxn\Framework\Http\Attribute\Length;
+use Rxn\Framework\Http\Attribute\Max;
+use Rxn\Framework\Http\Attribute\Min;
+use Rxn\Framework\Http\Attribute\NotBlank;
+use Rxn\Framework\Http\Attribute\Required;
+use Rxn\Framework\Http\Attribute\Url;
+use Rxn\Framework\Http\Binding\RequestDto;
+
+/**
+ * Emit a polyparity YAML spec from a Rxn `RequestDto`. The same
+ * schema-as-truth principle applies: one PHP class drives Rxn's
+ * Binder, the JS twin via `JsValidatorEmitter`, AND a polyparity
+ * spec consumable by the polyparity TS / Python / PHP / future
+ * implementations.
+ *
+ *   $yaml = (new PolyparityExporter())->emit(CreateProduct::class);
+ *   file_put_contents('create-product.spec.yaml', $yaml);
+ *
+ * Polyparity (https://github.com/davidwyly/polyparity, private)
+ * is a language-neutral spec format with native validators in
+ * each target ecosystem. This exporter is the bridge: PHP shops
+ * with polyglot frontends can drive both the PHP server and the
+ * polyparity-generated client validators from the same DTO.
+ *
+ * Coverage matrix: identical to `JsValidatorEmitter` —
+ * Required, NotBlank, Length, Min, Max, InSet, Email, Url, plus
+ * the four scalar types (string, int, float, bool). Same refusal
+ * on Pattern / Uuid / Json / Date / StartsWith / EndsWith — those
+ * have known cross-runtime divergences in polyparity too.
+ */
+final class PolyparityExporter
+{
+    public function emit(string $class): string
+    {
+        $reflection = new \ReflectionClass($class);
+        if (!$reflection->implementsInterface(RequestDto::class)) {
+            throw new \InvalidArgumentException("$class must implement " . RequestDto::class);
+        }
+
+        $yaml  = "version: 0.1\n";
+        $yaml .= "schema:\n";
+        $yaml .= '  name: ' . $reflection->getShortName() . "\n";
+        $yaml .= "  fields:\n";
+
+        foreach ($reflection->getProperties(\ReflectionProperty::IS_PUBLIC) as $prop) {
+            if ($prop->isStatic()) {
+                continue;
+            }
+            $yaml .= $this->emitProperty($prop);
+        }
+
+        return $yaml;
+    }
+
+    private function emitProperty(\ReflectionProperty $prop): string
+    {
+        $name       = $prop->getName();
+        $type       = $prop->getType();
+        $isRequired = $prop->getAttributes(Required::class) !== [];
+        $allowsNull = $type instanceof \ReflectionNamedType && $type->allowsNull();
+        $hasDefault = $prop->hasDefaultValue();
+        $default    = $hasDefault ? $prop->getDefaultValue() : null;
+
+        $lines = [];
+        $lines[] = '    ' . $name . ':';
+        $lines[] = '      type: ' . $this->mapType($type, $name);
+
+        if ($isRequired) {
+            $lines[] = '      required: true';
+        }
+        if ($allowsNull) {
+            $lines[] = '      nullable: true';
+        }
+        if ($hasDefault && $default !== null) {
+            $lines[] = '      default: ' . $this->yamlScalar($default);
+        }
+
+        $constraints = $this->emitAttributes($prop);
+        foreach ($constraints as $line) {
+            $lines[] = '      ' . $line;
+        }
+
+        return implode("\n", $lines) . "\n\n";
+    }
+
+    private function mapType(?\ReflectionType $type, string $propName): string
+    {
+        if (!$type instanceof \ReflectionNamedType) {
+            throw new \RuntimeException(
+                "PolyparityExporter: property '$propName' has no scalar type. "
+                . 'Polyparity requires string|int|float|bool.',
+            );
+        }
+        return match ($type->getName()) {
+            'string' => 'string',
+            'int'    => 'int',
+            'float'  => 'float',
+            'bool'   => 'bool',
+            default  => throw new \RuntimeException(
+                "PolyparityExporter: property '$propName' has unsupported type '"
+                . $type->getName()
+                . "'. Polyparity supports string|int|float|bool only.",
+            ),
+        };
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function emitAttributes(\ReflectionProperty $prop): array
+    {
+        $out = [];
+        foreach ($prop->getAttributes() as $attr) {
+            $name = $attr->getName();
+            if ($name === Required::class) {
+                continue;
+            }
+            $line = $this->emitAttribute($name, $attr->getArguments(), $prop->getName());
+            if ($line !== null) {
+                $out[] = $line;
+            }
+        }
+        return $out;
+    }
+
+    /**
+     * @param array<int|string, mixed> $args
+     */
+    private function emitAttribute(string $name, array $args, string $propName): ?string
+    {
+        return match ($name) {
+            NotBlank::class => 'not_blank: true',
+            Length::class   => $this->emitLength($args),
+            Min::class      => 'min: ' . $this->yamlScalar($args[0] ?? $args['min'] ?? 0),
+            Max::class      => 'max: ' . $this->yamlScalar($args[0] ?? $args['max'] ?? 0),
+            InSet::class    => $this->emitInSet($args),
+            Url::class      => 'url: true',
+            Email::class    => 'email: true',
+            default         => $this->refuse($name, $propName),
+        };
+    }
+
+    private function refuse(string $attrName, string $propName): ?string
+    {
+        $known = ['Pattern', 'Uuid', 'Json', 'Date', 'StartsWith', 'EndsWith'];
+        $short = (new \ReflectionClass($attrName))->getShortName();
+        if (in_array($short, $known, true)) {
+            throw new \RuntimeException(
+                "PolyparityExporter: $attrName on property '$propName' has no polyparity twin yet. "
+                . 'Refusing to emit silently-divergent spec. '
+                . 'Add a mapping or document the DTO as PHP-only.',
+            );
+        }
+        return null;
+    }
+
+    /**
+     * @param array<int|string, mixed> $args
+     */
+    private function emitLength(array $args): string
+    {
+        $min = $args[0] ?? $args['min'] ?? null;
+        $max = $args[1] ?? $args['max'] ?? null;
+        $parts = [];
+        if ($min !== null) {
+            $parts[] = 'min: ' . (int) $min;
+        }
+        if ($max !== null) {
+            $parts[] = 'max: ' . (int) $max;
+        }
+        return 'length: { ' . implode(', ', $parts) . ' }';
+    }
+
+    /**
+     * @param array<int|string, mixed> $args
+     */
+    private function emitInSet(array $args): string
+    {
+        $values = $args[0] ?? $args['values'] ?? [];
+        if (!is_array($values)) {
+            throw new \InvalidArgumentException('InSet expects an array of values');
+        }
+        $rendered = array_map(fn ($v): string => $this->yamlScalar($v), $values);
+        return 'one_of: [' . implode(', ', $rendered) . ']';
+    }
+
+    private function yamlScalar(mixed $v): string
+    {
+        if ($v === null) {
+            return 'null';
+        }
+        if (is_bool($v)) {
+            return $v ? 'true' : 'false';
+        }
+        if (is_int($v)) {
+            return (string) $v;
+        }
+        if (is_float($v)) {
+            $s = (string) $v;
+            return str_contains($s, '.') || str_contains($s, 'e') || str_contains($s, 'E')
+                ? $s
+                : $s . '.0';
+        }
+        if (is_string($v)) {
+            return $this->yamlString($v);
+        }
+        throw new \InvalidArgumentException('Unsupported YAML scalar type: ' . get_debug_type($v));
+    }
+
+    private function yamlString(string $s): string
+    {
+        if ($s === '') {
+            return "''";
+        }
+        if ($this->needsQuoting($s)) {
+            $escaped = str_replace("'", "''", $s);
+            return "'" . $escaped . "'";
+        }
+        return $s;
+    }
+
+    private function needsQuoting(string $s): bool
+    {
+        if (preg_match('/^[A-Za-z_][A-Za-z0-9_\-]*$/', $s) !== 1) {
+            return true;
+        }
+        $reserved = ['true', 'false', 'null', 'yes', 'no', 'on', 'off', '~'];
+        if (in_array(strtolower($s), $reserved, true)) {
+            return true;
+        }
+        return false;
+    }
+}

--- a/src/Rxn/Framework/Tests/Codegen/PolyparityExporterTest.php
+++ b/src/Rxn/Framework/Tests/Codegen/PolyparityExporterTest.php
@@ -1,0 +1,193 @@
+<?php declare(strict_types=1);
+
+namespace Rxn\Framework\Tests\Codegen;
+
+use PHPUnit\Framework\TestCase;
+use Rxn\Framework\Codegen\PolyparityExporter;
+
+/**
+ * Snapshot tests for the polyparity YAML exporter. Each test
+ * locks the exact YAML output for a given DTO so any drift in
+ * either the exporter logic or the source DTO surfaces as an
+ * explicit diff in the assertion.
+ *
+ * Out-of-scope attributes (Pattern / Uuid / Json / Date /
+ * StartsWith / EndsWith) trigger refusal — same posture as the
+ * `JsValidatorEmitter`. Silent divergence is the worst failure
+ * mode.
+ */
+final class PolyparityExporterTest extends TestCase
+{
+    public function testEmitsParityDtoSpec(): void
+    {
+        $expected = <<<YAML
+        version: 0.1
+        schema:
+          name: ParityDto
+          fields:
+            name:
+              type: string
+              required: true
+              not_blank: true
+              length: { min: 1, max: 100 }
+
+            price:
+              type: int
+              required: true
+              min: 0
+              max: 1000000
+
+            status:
+              type: string
+              default: draft
+              one_of: [draft, published, archived]
+
+            featured:
+              type: bool
+              default: false
+
+            homepage:
+              type: string
+              nullable: true
+              url: true
+
+            email:
+              type: string
+              nullable: true
+              email: true
+
+
+        YAML;
+
+        $actual = (new PolyparityExporter())->emit(Fixture\ParityDto::class);
+        $this->assertSame($expected, $actual);
+    }
+
+    public function testEmitsKitchenSinkDtoSpec(): void
+    {
+        $expected = <<<YAML
+        version: 0.1
+        schema:
+          name: KitchenSinkDto
+          fields:
+            title:
+              type: string
+              required: true
+              not_blank: true
+              length: { min: 3, max: 50 }
+
+            description:
+              type: string
+              default: ''
+              length: { max: 500 }
+
+            quantity:
+              type: int
+              required: true
+              min: 0
+              max: 1000000
+
+            unitPrice:
+              type: float
+              required: true
+              min: 0.01
+              max: 99999.99
+
+            currency:
+              type: string
+              default: USD
+              one_of: [USD, EUR, GBP, JPY]
+
+            state:
+              type: string
+              default: draft
+              one_of: [draft, review, approved, rejected]
+
+            taxable:
+              type: bool
+              default: true
+
+            featured:
+              type: bool
+              nullable: true
+
+            imageUrl:
+              type: string
+              nullable: true
+              url: true
+
+            contact:
+              type: string
+              nullable: true
+              email: true
+
+            countryCode:
+              type: string
+              nullable: true
+              length: { min: 2, max: 2 }
+
+
+        YAML;
+
+        $actual = (new PolyparityExporter())->emit(Fixture\KitchenSinkDto::class);
+        $this->assertSame($expected, $actual);
+    }
+
+    public function testEmitsNumericEdgeDtoSpec(): void
+    {
+        $expected = <<<YAML
+        version: 0.1
+        schema:
+          name: NumericEdgeDto
+          fields:
+            strictInt:
+              type: int
+              required: true
+
+            boundedInt:
+              type: int
+              default: 0
+              min: -100
+              max: 100
+
+            strictFloat:
+              type: float
+              required: true
+
+            boundedFloat:
+              type: float
+              default: 0.0
+              min: -1.5
+              max: 1.5
+
+            optionalInt:
+              type: int
+              nullable: true
+
+            optionalFloat:
+              type: float
+              nullable: true
+
+
+        YAML;
+
+        $actual = (new PolyparityExporter())->emit(Fixture\NumericEdgeDto::class);
+        $this->assertSame($expected, $actual);
+    }
+
+    public function testRefusesUnsupportedAttribute(): void
+    {
+        $exporter = new PolyparityExporter();
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessageMatches('/Pattern.*no polyparity twin/i');
+        $exporter->emit(Fixture\UnsupportedDto::class);
+    }
+
+    public function testRejectsNonRequestDto(): void
+    {
+        $exporter = new PolyparityExporter();
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessageMatches('/must implement/i');
+        $exporter->emit(\stdClass::class);
+    }
+}


### PR DESCRIPTION
## Summary

Adds `Rxn\Framework\Codegen\PolyparityExporter`, a third consumer of the schema-as-truth DTO. The same `RequestDto` class now drives:

1. **Rxn's PHP server** — via `Binder::bind` / `Binder::compileFor`
2. **The JS twin** — via `Codegen\JsValidatorEmitter`
3. **A polyparity YAML spec** — via this new exporter, consumable by [polyparity](https://github.com/davidwyly/polyparity)'s TS / Python / future-language siblings

## Why this matters

Polyparity is the language-neutral home for the cross-language validator parity work that PR #14's rolled-back framing acknowledged should not live in PHP. This exporter is the on-ramp for PHP shops with polyglot frontends: keep writing DTOs in PHP, get a polyparity spec for free.

## Coverage

Mirrors `JsValidatorEmitter` exactly:

| Attribute | Polyparity YAML |
|---|---|
| `#[Required]` | `required: true` |
| `#[NotBlank]` | `not_blank: true` |
| `#[Length(min, max)]` | `length: { min: N, max: N }` |
| `#[Min(n)]` | `min: N` |
| `#[Max(n)]` | `max: N` |
| `#[InSet([...])]` | `one_of: [...]` |
| `#[Url]` | `url: true` |
| `#[Email]` | `email: true` |
| Scalar type | `type: string\|int\|float\|bool` |
| `?T` (nullable) | `nullable: true` |
| `= 'foo'` (default) | `default: foo` |

Out-of-scope attributes (`Pattern`, `Uuid`, `Json`, `Date`, `StartsWith`, `EndsWith`) trigger `RuntimeException` — same refusal posture as the JS emitter. Silent divergence is the worst failure mode.

## Tests

- `PolyparityExporterTest` — snapshot tests for `ParityDto`, `KitchenSinkDto`, `NumericEdgeDto`.
- Refusal test for `UnsupportedDto` (uses `#[Pattern]`).
- Reject test for non-`RequestDto` classes.
- **Verified end-to-end via one-shot smoke test through polyparity-php's `Validator::compile()`** — the seven exercised cases (valid full payload, missing required, invalid InSet, invalid Length, invalid url, invalid email, int round-trip rejection) match expected polyparity verdicts. The smoke test isn't part of the permanent suite (would require polyparity-php as a Composer dep, which we intentionally don't have); the snapshot tests are the ongoing guarantee.

## Test plan

- [x] `vendor/bin/phpunit` — 565 tests / 1166 assertions, all green
- [x] Smoke-tested end-to-end against polyparity-php
- [x] Zero new dependencies
- [x] Zero hot-path code touched