### PR TITLE
fix(bench): include zero-count windows in median-window RPS

### DIFF
--- a/bench/compare/load.php
+++ b/bench/compare/load.php
@@ -160,13 +160,20 @@ final class Load
         // last bin ends mid-tick) and take the median of the rest.
         // Multiplied to req/sec from req/100ms.
         $rpsMedianWindow = 0.0;
-        if (count($windowCounts) > 2) {
+        if (count($windowCounts) > 0) {
             ksort($windowCounts);
-            $bins = array_values($windowCounts);
-            $bins = array_slice($bins, 1, -1);
-            sort($bins);
-            $mid = $bins[(int) (count($bins) / 2)];
-            $rpsMedianWindow = $mid * (1000.0 / $windowMs);
+            $firstBin = (int) array_key_first($windowCounts);
+            $lastBin = (int) array_key_last($windowCounts);
+            $bins = [];
+            for ($b = $firstBin; $b <= $lastBin; $b++) {
+                $bins[] = $windowCounts[$b] ?? 0;
+            }
+            if (count($bins) > 2) {
+                $bins = array_slice($bins, 1, -1);
+                sort($bins);
+                $mid = $bins[(int) (count($bins) / 2)];
+                $rpsMedianWindow = $mid * (1000.0 / $windowMs);
+            }
         }
 
         ksort($statusCounts);

--- a/bench/compare/load.php
+++ b/bench/compare/load.php
@@ -159,17 +159,22 @@ final class Load
         // populated at run boundaries — first bin starts mid-warmup,
         // last bin ends mid-tick) and take the median of the rest.
         // Multiplied to req/sec from req/100ms.
+        //
+        // The bin range is the *intended* run window [0, maxBin], not
+        // [first observed, last observed]. Anchoring to observed
+        // completions would silently drop:
+        //   - zero-count windows at the start (slow first response
+        //     pushes all completions to bin >0)
+        //   - zero-count windows at the end (no completions in the
+        //     final 100ms — a real tail-stall worth measuring)
+        // Late completions past `$deadline` (up to CURLOPT_TIMEOUT_MS)
+        // already land in bins past `$maxBin` and are excluded by the
+        // range, not by the bin-key clamp.
         $rpsMedianWindow = 0.0;
         if (count($windowCounts) > 0) {
             ksort($windowCounts);
-            $firstBin = (int) array_key_first($windowCounts);
-            // Clamp to the last bin that falls within the intended timed run.
-            // Without this, a single slow request completing well after the
-            // deadline (up to CURLOPT_TIMEOUT_MS later) would cause the range
-            // loop to synthesise a large block of zero-count bins that aren't
-            // part of the run, dragging the median down toward 0.
-            $maxBin  = (int) ceil($duration * 1000.0 / $windowMs) - 1;
-            $lastBin = min((int) array_key_last($windowCounts), $maxBin);
+            $firstBin = 0;
+            $lastBin  = (int) ceil($duration * 1000.0 / $windowMs) - 1;
             $bins = [];
             for ($b = $firstBin; $b <= $lastBin; $b++) {
                 $bins[] = $windowCounts[$b] ?? 0;

--- a/bench/compare/load.php
+++ b/bench/compare/load.php
@@ -163,7 +163,13 @@ final class Load
         if (count($windowCounts) > 0) {
             ksort($windowCounts);
             $firstBin = (int) array_key_first($windowCounts);
-            $lastBin = (int) array_key_last($windowCounts);
+            // Clamp to the last bin that falls within the intended timed run.
+            // Without this, a single slow request completing well after the
+            // deadline (up to CURLOPT_TIMEOUT_MS later) would cause the range
+            // loop to synthesise a large block of zero-count bins that aren't
+            // part of the run, dragging the median down toward 0.
+            $maxBin  = (int) ceil($duration * 1000.0 / $windowMs) - 1;
+            $lastBin = min((int) array_key_last($windowCounts), $maxBin);
             $bins = [];
             for ($b = $firstBin; $b <= $lastBin; $b++) {
                 $bins[] = $windowCounts[$b] ?? 0;

--- a/composer.lock
+++ b/composer.lock
@@ -4,68 +4,8 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "aa45b62c5ae2739708c65656bcf59294",
+    "content-hash": "ca59634b4bdac3912fc6bc7ebdebafa9",
     "packages": [
-        {
-            "name": "davidwyly/rxn-orm",
-            "version": "v0.1.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/davidwyly/rxn-orm.git",
-                "reference": "aa8662f0f4eeff5d57b16d1c20f34285d06a6777"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/davidwyly/rxn-orm/zipball/aa8662f0f4eeff5d57b16d1c20f34285d06a6777",
-                "reference": "aa8662f0f4eeff5d57b16d1c20f34285d06a6777",
-                "shasum": ""
-            },
-            "require": {
-                "ext-pdo": "*",
-                "php": "^8.1"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^10.5"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "Rxn\\Orm\\": "src/"
-                }
-            },
-            "autoload-dev": {
-                "psr-4": {
-                    "Rxn\\Orm\\Tests\\": "tests/"
-                }
-            },
-            "scripts": {
-                "test": [
-                    "phpunit"
-                ]
-            },
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "David Wyly",
-                    "email": "david.wyly@gmail.com"
-                }
-            ],
-            "description": "Fluent SQL query builder (SELECT / INSERT / UPDATE / DELETE) with subqueries, upsert, and RETURNING. Extracted from the Rxn framework; usable standalone on any PDO connection.",
-            "keywords": [
-                "orm",
-                "pdo",
-                "query-builder",
-                "rxn",
-                "sql"
-            ],
-            "support": {
-                "source": "https://github.com/davidwyly/rxn-orm/tree/v0.1.0",
-                "issues": "https://github.com/davidwyly/rxn-orm/issues"
-            },
-            "time": "2026-04-18T13:33:49+00:00"
-        },
         {
             "name": "nyholm/psr7",
             "version": "1.8.2",
@@ -284,6 +224,109 @@
                 }
             ],
             "time": "2025-12-27T19:41:33+00:00"
+        },
+        {
+            "name": "psr/container",
+            "version": "2.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/container.git",
+                "reference": "c71ecc56dfe541dbd90c5360474fbc405f8d5963"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/container/zipball/c71ecc56dfe541dbd90c5360474fbc405f8d5963",
+                "reference": "c71ecc56dfe541dbd90c5360474fbc405f8d5963",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.4.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Container\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "https://www.php-fig.org/"
+                }
+            ],
+            "description": "Common Container Interface (PHP FIG PSR-11)",
+            "homepage": "https://github.com/php-fig/container",
+            "keywords": [
+                "PSR-11",
+                "container",
+                "container-interface",
+                "container-interop",
+                "psr"
+            ],
+            "support": {
+                "issues": "https://github.com/php-fig/container/issues",
+                "source": "https://github.com/php-fig/container/tree/2.0.2"
+            },
+            "time": "2021-11-05T16:47:00+00:00"
+        },
+        {
+            "name": "psr/event-dispatcher",
+            "version": "1.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/event-dispatcher.git",
+                "reference": "dbefd12671e8a14ec7f180cab83036ed26714bb0"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/event-dispatcher/zipball/dbefd12671e8a14ec7f180cab83036ed26714bb0",
+                "reference": "dbefd12671e8a14ec7f180cab83036ed26714bb0",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.2.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\EventDispatcher\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "http://www.php-fig.org/"
+                }
+            ],
+            "description": "Standard interfaces for event handling.",
+            "keywords": [
+                "events",
+                "psr",
+                "psr-14"
+            ],
+            "support": {
+                "issues": "https://github.com/php-fig/event-dispatcher/issues",
+                "source": "https://github.com/php-fig/event-dispatcher/tree/1.0.0"
+            },
+            "time": "2019-01-08T18:20:26+00:00"
         },
         {
             "name": "psr/http-factory",
@@ -507,6 +550,56 @@
             "time": "2023-04-11T06:14:47+00:00"
         },
         {
+            "name": "psr/log",
+            "version": "3.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/log.git",
+                "reference": "f16e1d5863e37f8d8c2a01719f5b34baa2b714d3"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/log/zipball/f16e1d5863e37f8d8c2a01719f5b34baa2b714d3",
+                "reference": "f16e1d5863e37f8d8c2a01719f5b34baa2b714d3",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.0.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Log\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "https://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interface for logging libraries",
+            "homepage": "https://github.com/php-fig/log",
+            "keywords": [
+                "log",
+                "psr",
+                "psr-3"
+            ],
+            "support": {
+                "source": "https://github.com/php-fig/log/tree/3.0.2"
+            },
+            "time": "2024-09-11T13:17:53+00:00"
+        },
+        {
             "name": "symfony/polyfill-ctype",
             "version": "v1.36.0",
             "source": {
@@ -668,6 +761,66 @@
         }
     ],
     "packages-dev": [
+        {
+            "name": "davidwyly/rxn-orm",
+            "version": "v0.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/davidwyly/rxn-orm.git",
+                "reference": "aa8662f0f4eeff5d57b16d1c20f34285d06a6777"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/davidwyly/rxn-orm/zipball/aa8662f0f4eeff5d57b16d1c20f34285d06a6777",
+                "reference": "aa8662f0f4eeff5d57b16d1c20f34285d06a6777",
+                "shasum": ""
+            },
+            "require": {
+                "ext-pdo": "*",
+                "php": "^8.1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^10.5"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Rxn\\Orm\\": "src/"
+                }
+            },
+            "autoload-dev": {
+                "psr-4": {
+                    "Rxn\\Orm\\Tests\\": "tests/"
+                }
+            },
+            "scripts": {
+                "test": [
+                    "phpunit"
+                ]
+            },
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "David Wyly",
+                    "email": "david.wyly@gmail.com"
+                }
+            ],
+            "description": "Fluent SQL query builder (SELECT / INSERT / UPDATE / DELETE) with subqueries, upsert, and RETURNING. Extracted from the Rxn framework; usable standalone on any PDO connection.",
+            "keywords": [
+                "orm",
+                "pdo",
+                "query-builder",
+                "rxn",
+                "sql"
+            ],
+            "support": {
+                "source": "https://github.com/davidwyly/rxn-orm/tree/v0.1.0",
+                "issues": "https://github.com/davidwyly/rxn-orm/issues"
+            },
+            "time": "2026-04-18T13:33:49+00:00"
+        },
         {
             "name": "myclabs/deep-copy",
             "version": "1.13.4",
@@ -2344,8 +2497,8 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": "^8.1"
+        "php": "^8.2"
     },
     "platform-dev": {},
-    "plugin-api-version": "2.6.0"
+    "plugin-api-version": "2.9.0"
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,68 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "ca59634b4bdac3912fc6bc7ebdebafa9",
+    "content-hash": "aa45b62c5ae2739708c65656bcf59294",
     "packages": [
+        {
+            "name": "davidwyly/rxn-orm",
+            "version": "v0.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/davidwyly/rxn-orm.git",
+                "reference": "aa8662f0f4eeff5d57b16d1c20f34285d06a6777"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/davidwyly/rxn-orm/zipball/aa8662f0f4eeff5d57b16d1c20f34285d06a6777",
+                "reference": "aa8662f0f4eeff5d57b16d1c20f34285d06a6777",
+                "shasum": ""
+            },
+            "require": {
+                "ext-pdo": "*",
+                "php": "^8.1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^10.5"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Rxn\\Orm\\": "src/"
+                }
+            },
+            "autoload-dev": {
+                "psr-4": {
+                    "Rxn\\Orm\\Tests\\": "tests/"
+                }
+            },
+            "scripts": {
+                "test": [
+                    "phpunit"
+                ]
+            },
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "David Wyly",
+                    "email": "david.wyly@gmail.com"
+                }
+            ],
+            "description": "Fluent SQL query builder (SELECT / INSERT / UPDATE / DELETE) with subqueries, upsert, and RETURNING. Extracted from the Rxn framework; usable standalone on any PDO connection.",
+            "keywords": [
+                "orm",
+                "pdo",
+                "query-builder",
+                "rxn",
+                "sql"
+            ],
+            "support": {
+                "source": "https://github.com/davidwyly/rxn-orm/tree/v0.1.0",
+                "issues": "https://github.com/davidwyly/rxn-orm/issues"
+            },
+            "time": "2026-04-18T13:33:49+00:00"
+        },
         {
             "name": "nyholm/psr7",
             "version": "1.8.2",
@@ -224,109 +284,6 @@
                 }
             ],
             "time": "2025-12-27T19:41:33+00:00"
-        },
-        {
-            "name": "psr/container",
-            "version": "2.0.2",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/php-fig/container.git",
-                "reference": "c71ecc56dfe541dbd90c5360474fbc405f8d5963"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/php-fig/container/zipball/c71ecc56dfe541dbd90c5360474fbc405f8d5963",
-                "reference": "c71ecc56dfe541dbd90c5360474fbc405f8d5963",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=7.4.0"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "2.0.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Psr\\Container\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "PHP-FIG",
-                    "homepage": "https://www.php-fig.org/"
-                }
-            ],
-            "description": "Common Container Interface (PHP FIG PSR-11)",
-            "homepage": "https://github.com/php-fig/container",
-            "keywords": [
-                "PSR-11",
-                "container",
-                "container-interface",
-                "container-interop",
-                "psr"
-            ],
-            "support": {
-                "issues": "https://github.com/php-fig/container/issues",
-                "source": "https://github.com/php-fig/container/tree/2.0.2"
-            },
-            "time": "2021-11-05T16:47:00+00:00"
-        },
-        {
-            "name": "psr/event-dispatcher",
-            "version": "1.0.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/php-fig/event-dispatcher.git",
-                "reference": "dbefd12671e8a14ec7f180cab83036ed26714bb0"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/php-fig/event-dispatcher/zipball/dbefd12671e8a14ec7f180cab83036ed26714bb0",
-                "reference": "dbefd12671e8a14ec7f180cab83036ed26714bb0",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=7.2.0"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.0.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Psr\\EventDispatcher\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "PHP-FIG",
-                    "homepage": "http://www.php-fig.org/"
-                }
-            ],
-            "description": "Standard interfaces for event handling.",
-            "keywords": [
-                "events",
-                "psr",
-                "psr-14"
-            ],
-            "support": {
-                "issues": "https://github.com/php-fig/event-dispatcher/issues",
-                "source": "https://github.com/php-fig/event-dispatcher/tree/1.0.0"
-            },
-            "time": "2019-01-08T18:20:26+00:00"
         },
         {
             "name": "psr/http-factory",
@@ -550,56 +507,6 @@
             "time": "2023-04-11T06:14:47+00:00"
         },
         {
-            "name": "psr/log",
-            "version": "3.0.2",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/php-fig/log.git",
-                "reference": "f16e1d5863e37f8d8c2a01719f5b34baa2b714d3"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/php-fig/log/zipball/f16e1d5863e37f8d8c2a01719f5b34baa2b714d3",
-                "reference": "f16e1d5863e37f8d8c2a01719f5b34baa2b714d3",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=8.0.0"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "3.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Psr\\Log\\": "src"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "PHP-FIG",
-                    "homepage": "https://www.php-fig.org/"
-                }
-            ],
-            "description": "Common interface for logging libraries",
-            "homepage": "https://github.com/php-fig/log",
-            "keywords": [
-                "log",
-                "psr",
-                "psr-3"
-            ],
-            "support": {
-                "source": "https://github.com/php-fig/log/tree/3.0.2"
-            },
-            "time": "2024-09-11T13:17:53+00:00"
-        },
-        {
             "name": "symfony/polyfill-ctype",
             "version": "v1.36.0",
             "source": {
@@ -761,66 +668,6 @@
         }
     ],
     "packages-dev": [
-        {
-            "name": "davidwyly/rxn-orm",
-            "version": "v0.1.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/davidwyly/rxn-orm.git",
-                "reference": "aa8662f0f4eeff5d57b16d1c20f34285d06a6777"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/davidwyly/rxn-orm/zipball/aa8662f0f4eeff5d57b16d1c20f34285d06a6777",
-                "reference": "aa8662f0f4eeff5d57b16d1c20f34285d06a6777",
-                "shasum": ""
-            },
-            "require": {
-                "ext-pdo": "*",
-                "php": "^8.1"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^10.5"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "Rxn\\Orm\\": "src/"
-                }
-            },
-            "autoload-dev": {
-                "psr-4": {
-                    "Rxn\\Orm\\Tests\\": "tests/"
-                }
-            },
-            "scripts": {
-                "test": [
-                    "phpunit"
-                ]
-            },
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "David Wyly",
-                    "email": "david.wyly@gmail.com"
-                }
-            ],
-            "description": "Fluent SQL query builder (SELECT / INSERT / UPDATE / DELETE) with subqueries, upsert, and RETURNING. Extracted from the Rxn framework; usable standalone on any PDO connection.",
-            "keywords": [
-                "orm",
-                "pdo",
-                "query-builder",
-                "rxn",
-                "sql"
-            ],
-            "support": {
-                "source": "https://github.com/davidwyly/rxn-orm/tree/v0.1.0",
-                "issues": "https://github.com/davidwyly/rxn-orm/issues"
-            },
-            "time": "2026-04-18T13:33:49+00:00"
-        },
         {
             "name": "myclabs/deep-copy",
             "version": "1.13.4",
@@ -2497,8 +2344,8 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": "^8.2"
+        "php": "^8.1"
     },
     "platform-dev": {},
-    "plugin-api-version": "2.9.0"
+    "plugin-api-version": "2.6.0"
 }


### PR DESCRIPTION
### Motivation
- Correct a benchmark-reporting bug where the median 100ms-window throughput ignored empty interior windows and could therefore overstate throughput; the previous code computed the median only over populated bins.

### Description
- Update the median-window calculation in `bench/compare/load.php` to build a contiguous bin series from `array_key_first` to `array_key_last` and fill missing bins with `0` before computing the median.
- Preserve the existing behavior of dropping the first and last bins (partial boundary bins) and scaling the median count to req/sec using the existing `1000.0 / $windowMs` factor.
- Scope the change to the single metric path for `rps_median_window` with no other behavioral changes to reporting.

### Testing
- Ran `php -l bench/compare/load.php` and it reported no syntax errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f5964e5178832fa9a1d85dd78152e3)