### PR TITLE
fix(binder): cap inline JSON fallback body size

### DIFF
--- a/src/Rxn/Framework/Http/Binding/Binder.php
+++ b/src/Rxn/Framework/Http/Binding/Binder.php
@@ -16,6 +16,7 @@ use Rxn\Framework\Http\Attribute\Required;
 use Rxn\Framework\Http\Attribute\StartsWith;
 use Rxn\Framework\Http\Attribute\Url;
 use Rxn\Framework\Http\Attribute\Uuid;
+use Rxn\Framework\Http\Middleware\JsonBody;
 
 /**
  * Hydrate a `RequestDto` from the merged request bag (query +
@@ -34,8 +35,6 @@ use Rxn\Framework\Http\Attribute\Uuid;
  */
 final class Binder
 {
-    private const MAX_JSON_BYTES = 1048576;
-
     /**
      * Bind a DTO from a PSR-7 `ServerRequestInterface`. Pulls
      * query params + parsed body (or, when no parsed body is set,
@@ -678,21 +677,38 @@ final class Binder
         $contentType = strtolower(trim(explode(';', $request->getHeaderLine('Content-Type'), 2)[0]));
         if ($contentType === 'application/json') {
             $declared = (int)($request->getHeaderLine('Content-Length') ?: 0);
-            if ($declared > self::MAX_JSON_BYTES) {
+            if ($declared > JsonBody::DEFAULT_MAX_BYTES) {
                 return $query;
             }
             $body = $request->getBody();
-            if (!$body->isSeekable()) {
-                return $query;
-            }
             $size = $body->getSize();
-            if (is_int($size) && $size > self::MAX_JSON_BYTES) {
+            if (is_int($size) && $size > JsonBody::DEFAULT_MAX_BYTES) {
                 return $query;
             }
-            $body->rewind();
-            $raw = $body->read(self::MAX_JSON_BYTES + 1);
-            $body->rewind();
-            if (strlen($raw) > self::MAX_JSON_BYTES) {
+            // Loop-read to handle PSR-7 streams that may return partial
+            // chunks per read() call. We collect up to DEFAULT_MAX_BYTES+1
+            // bytes so we can detect oversized payloads before decoding.
+            // For seekable streams the body is rewound after peeking so
+            // downstream consumers see an untouched stream; for non-seekable
+            // streams the read consumes the data (matching the prior
+            // (string)$body behaviour).
+            $limit = JsonBody::DEFAULT_MAX_BYTES + 1;
+            $raw   = '';
+            while (!$body->eof()) {
+                $needed = $limit - strlen($raw);
+                if ($needed <= 0) {
+                    break;
+                }
+                $chunk = $body->read($needed);
+                if ($chunk === '') {
+                    break;
+                }
+                $raw .= $chunk;
+            }
+            if ($body->isSeekable()) {
+                $body->rewind();
+            }
+            if (strlen($raw) > JsonBody::DEFAULT_MAX_BYTES) {
                 return $query;
             }
             if ($raw !== '') {

--- a/src/Rxn/Framework/Http/Binding/Binder.php
+++ b/src/Rxn/Framework/Http/Binding/Binder.php
@@ -682,17 +682,16 @@ final class Binder
                 return $query;
             }
             $body = $request->getBody();
+            if (!$body->isSeekable()) {
+                return $query;
+            }
             $size = $body->getSize();
             if (is_int($size) && $size > self::MAX_JSON_BYTES) {
                 return $query;
             }
-            if ($body->isSeekable()) {
-                $body->rewind();
-            }
+            $body->rewind();
             $raw = $body->read(self::MAX_JSON_BYTES + 1);
-            if ($body->isSeekable()) {
-                $body->rewind();
-            }
+            $body->rewind();
             if (strlen($raw) > self::MAX_JSON_BYTES) {
                 return $query;
             }

--- a/src/Rxn/Framework/Http/Binding/Binder.php
+++ b/src/Rxn/Framework/Http/Binding/Binder.php
@@ -34,6 +34,8 @@ use Rxn\Framework\Http\Attribute\Uuid;
  */
 final class Binder
 {
+    private const MAX_JSON_BYTES = 1048576;
+
     /**
      * Bind a DTO from a PSR-7 `ServerRequestInterface`. Pulls
      * query params + parsed body (or, when no parsed body is set,
@@ -675,9 +677,24 @@ final class Binder
         // check; not running that middleware is now non-fatal.
         $contentType = strtolower(trim(explode(';', $request->getHeaderLine('Content-Type'), 2)[0]));
         if ($contentType === 'application/json') {
-            $raw = (string)$request->getBody();
-            if ($request->getBody()->isSeekable()) {
-                $request->getBody()->rewind();
+            $declared = (int)($request->getHeaderLine('Content-Length') ?: 0);
+            if ($declared > self::MAX_JSON_BYTES) {
+                return $query;
+            }
+            $body = $request->getBody();
+            $size = $body->getSize();
+            if (is_int($size) && $size > self::MAX_JSON_BYTES) {
+                return $query;
+            }
+            if ($body->isSeekable()) {
+                $body->rewind();
+            }
+            $raw = $body->read(self::MAX_JSON_BYTES + 1);
+            if ($body->isSeekable()) {
+                $body->rewind();
+            }
+            if (strlen($raw) > self::MAX_JSON_BYTES) {
+                return $query;
             }
             if ($raw !== '') {
                 $decoded = json_decode($raw, true);

--- a/src/Rxn/Framework/Http/Middleware/JsonBody.php
+++ b/src/Rxn/Framework/Http/Middleware/JsonBody.php
@@ -31,12 +31,15 @@ final class JsonBody implements MiddlewareInterface
 {
     private const BODY_METHODS = ['POST', 'PUT', 'PATCH'];
 
+    /** Maximum JSON body size in bytes (1 MiB). Shared with Binder's inline fallback. */
+    public const DEFAULT_MAX_BYTES = 1048576;
+
     private int $maxBytes;
 
     /**
      * @param int $maxBytes max accepted Content-Length (default 1 MiB)
      */
-    public function __construct(int $maxBytes = 1048576)
+    public function __construct(int $maxBytes = self::DEFAULT_MAX_BYTES)
     {
         $this->maxBytes = $maxBytes;
     }

--- a/src/Rxn/Framework/Http/Middleware/JsonBody.php
+++ b/src/Rxn/Framework/Http/Middleware/JsonBody.php
@@ -73,7 +73,34 @@ final class JsonBody implements MiddlewareInterface
             );
         }
 
-        $raw = (string)$request->getBody();
+        $body = $request->getBody();
+        $size = $body->getSize();
+        if (is_int($size) && $size > $this->maxBytes) {
+            throw new RequestException(
+                "Request body exceeds maximum of {$this->maxBytes} bytes",
+                413
+            );
+        }
+        // Loop-read with a hard cap so a request without Content-Length
+        // and without a known stream size cannot consume unbounded
+        // memory before the post-read check fires. We collect up to
+        // maxBytes+1 so we can still detect oversized payloads.
+        $limit = $this->maxBytes + 1;
+        $raw   = '';
+        while (!$body->eof()) {
+            $needed = $limit - strlen($raw);
+            if ($needed <= 0) {
+                break;
+            }
+            $chunk = $body->read($needed);
+            if ($chunk === '') {
+                break;
+            }
+            $raw .= $chunk;
+        }
+        if ($body->isSeekable()) {
+            $body->rewind();
+        }
         if ($raw === '') {
             return $handler->handle($request);
         }

--- a/src/Rxn/Framework/Tests/Http/Binding/BinderTest.php
+++ b/src/Rxn/Framework/Tests/Http/Binding/BinderTest.php
@@ -360,7 +360,8 @@ final class BinderTest extends TestCase
 
     public function testGatherFromRequestSkipsOversizedJsonWithoutDeclaredLength(): void
     {
-        $payload = json_encode(['blob' => str_repeat('a', 1048577)]);
+        $cap     = (new \ReflectionClassConstant(Binder::class, 'MAX_JSON_BYTES'))->getValue();
+        $payload = json_encode(['blob' => str_repeat('a', $cap + 1)]);
         $this->assertNotFalse($payload);
         $request = (new \Nyholm\Psr7\ServerRequest(
             'POST',

--- a/src/Rxn/Framework/Tests/Http/Binding/BinderTest.php
+++ b/src/Rxn/Framework/Tests/Http/Binding/BinderTest.php
@@ -6,6 +6,7 @@ use PHPUnit\Framework\TestCase;
 use Rxn\Framework\Codegen\DumpCache;
 use Rxn\Framework\Http\Binding\Binder;
 use Rxn\Framework\Http\Binding\ValidationException;
+use Rxn\Framework\Http\Middleware\JsonBody;
 use Rxn\Framework\Tests\Http\Binding\Fixture\Address;
 use Rxn\Framework\Tests\Http\Binding\Fixture\CreateProduct;
 
@@ -350,7 +351,7 @@ final class BinderTest extends TestCase
         $request = (new \Nyholm\Psr7\ServerRequest(
             'POST',
             'http://test.local/?q=1',
-            ['Content-Type' => 'application/json', 'Content-Length' => '2097152'],
+            ['Content-Type' => 'application/json', 'Content-Length' => (string)(JsonBody::DEFAULT_MAX_BYTES + 1)],
             json_encode(['name' => 'too-big']) ?: '',
         ))->withQueryParams(['q' => '1']);
 
@@ -360,7 +361,7 @@ final class BinderTest extends TestCase
 
     public function testGatherFromRequestSkipsOversizedJsonWithoutDeclaredLength(): void
     {
-        $maxJsonBytes = (new \ReflectionClassConstant(Binder::class, 'MAX_JSON_BYTES'))->getValue();
+        $maxJsonBytes = JsonBody::DEFAULT_MAX_BYTES;
         $payload      = json_encode(['blob' => str_repeat('a', $maxJsonBytes + 1)]);
         $this->assertNotFalse($payload);
         $request = (new \Nyholm\Psr7\ServerRequest(

--- a/src/Rxn/Framework/Tests/Http/Binding/BinderTest.php
+++ b/src/Rxn/Framework/Tests/Http/Binding/BinderTest.php
@@ -360,8 +360,8 @@ final class BinderTest extends TestCase
 
     public function testGatherFromRequestSkipsOversizedJsonWithoutDeclaredLength(): void
     {
-        $cap     = (new \ReflectionClassConstant(Binder::class, 'MAX_JSON_BYTES'))->getValue();
-        $payload = json_encode(['blob' => str_repeat('a', $cap + 1)]);
+        $maxJsonBytes = (new \ReflectionClassConstant(Binder::class, 'MAX_JSON_BYTES'))->getValue();
+        $payload      = json_encode(['blob' => str_repeat('a', $maxJsonBytes + 1)]);
         $this->assertNotFalse($payload);
         $request = (new \Nyholm\Psr7\ServerRequest(
             'POST',

--- a/src/Rxn/Framework/Tests/Http/Binding/BinderTest.php
+++ b/src/Rxn/Framework/Tests/Http/Binding/BinderTest.php
@@ -348,11 +348,13 @@ final class BinderTest extends TestCase
 
     public function testGatherFromRequestSkipsOversizedJsonFromDeclaredLength(): void
     {
+        $body = json_encode(['name' => 'too-big']);
+        $this->assertNotFalse($body, 'fixture json_encode must succeed');
         $request = (new \Nyholm\Psr7\ServerRequest(
             'POST',
             'http://test.local/?q=1',
             ['Content-Type' => 'application/json', 'Content-Length' => (string)(JsonBody::DEFAULT_MAX_BYTES + 1)],
-            json_encode(['name' => 'too-big']) ?: '',
+            $body,
         ))->withQueryParams(['q' => '1']);
 
         $bag = Binder::gatherFromRequest($request);
@@ -369,6 +371,27 @@ final class BinderTest extends TestCase
             'http://test.local/?q=1',
             ['Content-Type' => 'application/json'],
             $payload,
+        ))->withQueryParams(['q' => '1']);
+
+        $bag = Binder::gatherFromRequest($request);
+        $this->assertSame(['q' => '1'], $bag);
+    }
+
+    public function testGatherFromRequestSkipsOversizedJsonFromUnknownSizeStream(): void
+    {
+        $maxJsonBytes = JsonBody::DEFAULT_MAX_BYTES;
+        $payload      = json_encode(['blob' => str_repeat('a', $maxJsonBytes + 1)]);
+        $this->assertNotFalse($payload);
+
+        // Stream returns null from getSize() — exercises the loop-read
+        // cap directly. Without the cap, `(string)$body` would buffer
+        // the full payload before the post-read length check fires.
+        $stream  = new \Rxn\Framework\Tests\Http\Binding\Fixture\UnknownSizeStream($payload);
+        $request = (new \Nyholm\Psr7\ServerRequest(
+            'POST',
+            'http://test.local/?q=1',
+            ['Content-Type' => 'application/json'],
+            $stream,
         ))->withQueryParams(['q' => '1']);
 
         $bag = Binder::gatherFromRequest($request);

--- a/src/Rxn/Framework/Tests/Http/Binding/BinderTest.php
+++ b/src/Rxn/Framework/Tests/Http/Binding/BinderTest.php
@@ -345,6 +345,34 @@ final class BinderTest extends TestCase
         $this->assertSame(['q' => '1'], $bag);
     }
 
+    public function testGatherFromRequestSkipsOversizedJsonFromDeclaredLength(): void
+    {
+        $request = (new \Nyholm\Psr7\ServerRequest(
+            'POST',
+            'http://test.local/?q=1',
+            ['Content-Type' => 'application/json', 'Content-Length' => '2097152'],
+            json_encode(['name' => 'too-big']) ?: '',
+        ))->withQueryParams(['q' => '1']);
+
+        $bag = Binder::gatherFromRequest($request);
+        $this->assertSame(['q' => '1'], $bag);
+    }
+
+    public function testGatherFromRequestSkipsOversizedJsonWithoutDeclaredLength(): void
+    {
+        $payload = json_encode(['blob' => str_repeat('a', 1048577)]);
+        $this->assertNotFalse($payload);
+        $request = (new \Nyholm\Psr7\ServerRequest(
+            'POST',
+            'http://test.local/?q=1',
+            ['Content-Type' => 'application/json'],
+            $payload,
+        ))->withQueryParams(['q' => '1']);
+
+        $bag = Binder::gatherFromRequest($request);
+        $this->assertSame(['q' => '1'], $bag);
+    }
+
     // -------- dump path (Tier B) --------
 
     private string $dumpDir = '';

--- a/src/Rxn/Framework/Tests/Http/Binding/Fixture/UnknownSizeStream.php
+++ b/src/Rxn/Framework/Tests/Http/Binding/Fixture/UnknownSizeStream.php
@@ -1,0 +1,60 @@
+<?php declare(strict_types=1);
+
+namespace Rxn\Framework\Tests\Http\Binding\Fixture;
+
+use Psr\Http\Message\StreamInterface;
+
+/**
+ * PSR-7 stream that always reports `null` from `getSize()` and is
+ * non-seekable. Models the case where a request body lands as a
+ * pipe / forwarded stream whose total length is unknown until
+ * EOF.
+ *
+ * Returns chunks from `$payload` on each `read()` call so the
+ * loop-read path in `Binder::gatherFromRequest` and
+ * `JsonBody::process` actually exercises its cap-and-stop logic
+ * — `(string)$body` would otherwise still return the full payload.
+ */
+final class UnknownSizeStream implements StreamInterface
+{
+    private int $offset = 0;
+
+    public function __construct(private readonly string $payload) {}
+
+    public function __toString(): string
+    {
+        $rest = $this->getContents();
+        $this->offset = strlen($this->payload);
+        return $rest;
+    }
+
+    public function close(): void {}
+    public function detach() { return null; }
+    public function getSize(): ?int { return null; }
+    public function tell(): int { return $this->offset; }
+    public function eof(): bool { return $this->offset >= strlen($this->payload); }
+    public function isSeekable(): bool { return false; }
+    public function seek($offset, $whence = SEEK_SET): void
+    {
+        throw new \RuntimeException('not seekable');
+    }
+    public function rewind(): void { throw new \RuntimeException('not seekable'); }
+    public function isWritable(): bool { return false; }
+    public function write($string): int { throw new \RuntimeException('not writable'); }
+    public function isReadable(): bool { return true; }
+    public function read($length): string
+    {
+        $remaining = strlen($this->payload) - $this->offset;
+        $take      = max(0, min($length, $remaining));
+        $chunk     = substr($this->payload, $this->offset, $take);
+        $this->offset += strlen($chunk);
+        return $chunk;
+    }
+    public function getContents(): string
+    {
+        $rest = substr($this->payload, $this->offset);
+        $this->offset = strlen($this->payload);
+        return $rest;
+    }
+    public function getMetadata($key = null) { return $key === null ? [] : null; }
+}


### PR DESCRIPTION
### Motivation
- `Binder::gatherFromRequest()` previously decoded the raw PSR-7 body unbounded when `Content-Type: application/json`, which allows an attacker to force large allocations and cause denial-of-service.
- The project already has defensive checks in `JsonBody` middleware (declared length, actual length cap, and parse errors), so the inline fallback must match those protections.

### Description
- Add a `MAX_JSON_BYTES` (1 MiB) cap to `Binder` and short-circuit inline JSON decoding when the body exceeds that limit by declared `Content-Length` or known stream size via `getSize()`.
- Replace the unsafe full-body cast with a bounded stream read using `$body->read(MAX+1)` and rewind the stream after peeking to avoid loading unlimited data into memory.
- If the payload is oversized the binder now returns the query-only bag (preserving prior behavior by avoiding decoding), and only decodes when the bounded read is within limits and produces an array.
- Add two regression tests to `BinderTest` that assert oversized JSON is skipped both when a large `Content-Length` is declared and when the payload without `Content-Length` exceeds the cap.

### Testing
- Added unit tests: `testGatherFromRequestSkipsOversizedJsonFromDeclaredLength` and `testGatherFromRequestSkipsOversizedJsonWithoutDeclaredLength`, both committed to `src/Rxn/Framework/Tests/Http/Binding/BinderTest.php` and exercising `gatherFromRequest()` behavior.
- Attempted to run the test suite with `composer test` and `vendor/bin/phpunit`, but the environment is missing PHPUnit so the automated run failed with `phpunit: not found`.
- Static and manual inspection verified the new guards (`Content-Length`, `getSize()`, bounded `read`) are in place and avoid the previous unbounded `json_decode((string)$body)` path.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f695697224832f8c3ffe69b4729178)