### PR TITLE
fix(idempotency): only replay allowlisted response headers

### DIFF
--- a/src/Rxn/Framework/Http/Middleware/Idempotency.php
+++ b/src/Rxn/Framework/Http/Middleware/Idempotency.php
@@ -153,12 +153,21 @@ final class Idempotency implements MiddlewareInterface
      */
     private function filterReplayHeaders(array $headers): array
     {
+        // Build a lowercase-keyed index so allowlist matching is
+        // case-insensitive, mirroring PSR-7's case-insensitivity guarantee.
+        $normalized = [];
+        foreach ($headers as $name => $values) {
+            $normalized[strtolower($name)] = $values;
+        }
+
         $filtered = [];
         foreach ($this->replayHeaderAllowlist as $header) {
-            if (!isset($headers[$header])) {
+            $lower = strtolower($header);
+            if (!isset($normalized[$lower])) {
                 continue;
             }
-            $filtered[$header] = $headers[$header];
+            // Store under the allowlist's canonical casing.
+            $filtered[$header] = $normalized[$lower];
         }
         return $filtered;
     }

--- a/src/Rxn/Framework/Http/Middleware/Idempotency.php
+++ b/src/Rxn/Framework/Http/Middleware/Idempotency.php
@@ -166,8 +166,9 @@ final class Idempotency implements MiddlewareInterface
             if (!isset($normalized[$lower])) {
                 continue;
             }
-            // Store under the allowlist's canonical casing.
-            $filtered[$header] = $normalized[$lower];
+            // Store under lowercase keys to match PSR-7 normalisation
+            // conventions (see StoredResponse docblock).
+            $filtered[$lower] = $normalized[$lower];
         }
         return $filtered;
     }
@@ -215,9 +216,12 @@ final class Idempotency implements MiddlewareInterface
 
     private function renderStored(StoredResponse $stored): ResponseInterface
     {
+        // Re-apply the allowlist filter so that any StoredResponse
+        // persisted before this change (which may still contain
+        // unfiltered headers) does not replay sensitive headers.
         $response = new Psr7Response(
             $stored->statusCode,
-            $stored->headers,
+            $this->filterReplayHeaders($stored->headers),
             $stored->body,
         );
         return $response->withHeader('Idempotent-Replayed', 'true');

--- a/src/Rxn/Framework/Http/Middleware/Idempotency.php
+++ b/src/Rxn/Framework/Http/Middleware/Idempotency.php
@@ -61,6 +61,8 @@ final class Idempotency implements MiddlewareInterface
         /** @var list<string> */
         private readonly array  $methods        = ['POST', 'PUT', 'PATCH', 'DELETE'],
         private readonly int    $maxBodyBytes   = 1_048_576,
+        /** @var list<string> */
+        private readonly array  $replayHeaderAllowlist = ['Content-Type'],
         // Optional PSR-14 dispatcher. When provided, the middleware
         // emits `IdempotencyHit` on replay and `IdempotencyMiss`
         // when the cold path runs. Null → no allocation, no dispatch.
@@ -131,7 +133,7 @@ final class Idempotency implements MiddlewareInterface
                     $scopedKey,
                     new StoredResponse(
                         statusCode:  $response->getStatusCode(),
-                        headers:     $response->getHeaders(),
+                        headers:     $this->filterReplayHeaders($response->getHeaders()),
                         body:        $body,
                         fingerprint: $fingerprint,
                         createdAt:   time(),
@@ -143,6 +145,22 @@ final class Idempotency implements MiddlewareInterface
         } finally {
             $this->store->release($scopedKey);
         }
+    }
+
+    /**
+     * @param array<string, list<string>> $headers
+     * @return array<string, list<string>>
+     */
+    private function filterReplayHeaders(array $headers): array
+    {
+        $filtered = [];
+        foreach ($this->replayHeaderAllowlist as $header) {
+            if (!isset($headers[$header])) {
+                continue;
+            }
+            $filtered[$header] = $headers[$header];
+        }
+        return $filtered;
     }
 
     private function incomingKey(ServerRequestInterface $request): ?string

--- a/src/Rxn/Framework/Tests/Http/Middleware/IdempotencyTest.php
+++ b/src/Rxn/Framework/Tests/Http/Middleware/IdempotencyTest.php
@@ -166,6 +166,45 @@ final class IdempotencyTest extends TestCase
     }
 
 
+    public function testReplayAllowlistIsCaseInsensitive(): void
+    {
+        $store = $this->makeFileStore();
+
+        // Terminal response uses lowercase `content-type`; the allowlist
+        // entry is the title-cased `Content-Type`. The middleware must
+        // still replicate the header because PSR-7 names are case-insensitive.
+        $terminal = function (): ResponseInterface {
+            return new Psr7Response(
+                201,
+                [
+                    'content-type' => 'application/json',
+                    'Set-Cookie'   => 'session=victim',
+                ],
+                '{"data":{"id":9}}',
+            );
+        };
+
+        $this->runMiddleware(
+            $store,
+            method: 'POST',
+            headers: ['Idempotency-Key' => 'k-case'],
+            body: '{"a":1}',
+            terminal: $terminal,
+        );
+        $replayed = $this->runMiddleware(
+            $store,
+            method: 'POST',
+            headers: ['Idempotency-Key' => 'k-case'],
+            body: '{"a":1}',
+            terminal: $this->jsonTerminal(500, []),
+        );
+
+        $this->assertSame('application/json', $replayed->getHeaderLine('Content-Type'),
+            'allowlisted header must be replayed regardless of original casing');
+        $this->assertSame('', $replayed->getHeaderLine('Set-Cookie'),
+            'non-allowlisted header must not be replayed');
+    }
+
     public function testSameKeyDoesNotReplayAcrossAuthorizationScopes(): void
     {
         $store = $this->makeFileStore();

--- a/src/Rxn/Framework/Tests/Http/Middleware/IdempotencyTest.php
+++ b/src/Rxn/Framework/Tests/Http/Middleware/IdempotencyTest.php
@@ -129,6 +129,42 @@ final class IdempotencyTest extends TestCase
         $this->assertSame('true', $second->getHeaderLine('Idempotent-Replayed'));
     }
 
+    public function testReplayDoesNotReturnSensitiveHeaders(): void
+    {
+        $store = $this->makeFileStore();
+
+        $terminal = function (): ResponseInterface {
+            return new Psr7Response(
+                201,
+                [
+                    'Content-Type' => 'application/json',
+                    'Set-Cookie'   => 'session=victim',
+                    'X-Token'      => 'victim-token',
+                ],
+                '{"data":{"id":7}}',
+            );
+        };
+
+        $this->runMiddleware(
+            $store,
+            method: 'POST',
+            headers: ['Idempotency-Key' => 'k-sensitive'],
+            body: '{"a":1}',
+            terminal: $terminal,
+        );
+        $replayed = $this->runMiddleware(
+            $store,
+            method: 'POST',
+            headers: ['Idempotency-Key' => 'k-sensitive'],
+            body: '{"a":1}',
+            terminal: $this->jsonTerminal(201, ['id' => 8]),
+        );
+
+        $this->assertSame('application/json', $replayed->getHeaderLine('Content-Type'));
+        $this->assertSame('', $replayed->getHeaderLine('Set-Cookie'));
+        $this->assertSame('', $replayed->getHeaderLine('X-Token'));
+    }
+
 
     public function testSameKeyDoesNotReplayAcrossAuthorizationScopes(): void
     {

--- a/src/Rxn/Framework/Tests/Http/Middleware/IdempotencyTest.php
+++ b/src/Rxn/Framework/Tests/Http/Middleware/IdempotencyTest.php
@@ -133,7 +133,7 @@ final class IdempotencyTest extends TestCase
     {
         $store = $this->makeFileStore();
 
-        $terminal = function (): ResponseInterface {
+        $terminal = function (ServerRequestInterface $request): ResponseInterface {
             return new Psr7Response(
                 201,
                 [
@@ -173,7 +173,7 @@ final class IdempotencyTest extends TestCase
         // Terminal response uses lowercase `content-type`; the allowlist
         // entry is the title-cased `Content-Type`. The middleware must
         // still replicate the header because PSR-7 names are case-insensitive.
-        $terminal = function (): ResponseInterface {
+        $terminal = function (ServerRequestInterface $request): ResponseInterface {
             return new Psr7Response(
                 201,
                 [


### PR DESCRIPTION
### Motivation

- The idempotency middleware persisted and replayed the entire PSR-7 response header set, which can leak sensitive per-user headers (e.g. `Set-Cookie`, token rotation headers) when an `Idempotency-Key` collides or is reused across principals.
- The goal is to keep idempotency semantics while preventing replay of sensitive headers by limiting which headers are persisted and replayed.

### Description

- Added a `replayHeaderAllowlist` constructor property (default `['Content-Type']`) to `Idempotency` and used it to filter headers before storing a `StoredResponse` via `filterReplayHeaders`.
- Implemented `filterReplayHeaders(array $headers): array` which returns only allowlisted headers from the original response.
- Preserved existing scoping/fingerprint behavior (`scopedKey`, `fingerprint`) so key scoping and replay detection are unchanged.
- Added a regression test `testReplayDoesNotReturnSensitiveHeaders` to `src/Rxn/Framework/Tests/Http/Middleware/IdempotencyTest.php` that asserts `Content-Type` is preserved while `Set-Cookie` and a token header are not replayed.

Files changed: `src/Rxn/Framework/Http/Middleware/Idempotency.php`, `src/Rxn/Framework/Tests/Http/Middleware/IdempotencyTest.php`.

### Testing

- Added unit test `IdempotencyTest::testReplayDoesNotReturnSensitiveHeaders` to validate the header filtering behavior.
- Attempted to run the middleware test suite with `vendor/bin/phpunit` and `composer test`, but the environment lacks the `phpunit` executable so tests could not be executed here (command failed with `phpunit: not found`).
- No automated tests were run successfully in this environment; the new test is included and should pass when run in a dev environment with the project's test dependencies installed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f695694a64832fa78e0720a69bc1bd)