### PR TITLE
Fix dashboard fan-out timeout and upstream error handling

### DIFF
--- a/examples/products-api/public/index.php
+++ b/examples/products-api/public/index.php
@@ -174,18 +174,26 @@ $router->get('/dashboard/{id:int}', function (array $params, ServerRequestInterf
     ];
 
     $started = hrtime(true);
+    $bodies  = [];
     if ($mode === 'sequential') {
-        $bodies = [];
+        $ctx = stream_context_create(['http' => ['timeout' => 5.0]]);
         foreach ($urls as $key => $url) {
-            $bodies[$key] = (string) @file_get_contents($url);
+            $body = @file_get_contents($url, false, $ctx);
+            $bodies[$key] = $body !== false ? (string) $body : '';
         }
     } else {
-        $scheduler = new Scheduler();
-        $client    = new AsyncHttpClient($scheduler);
-        $bodies = $scheduler->run(static fn (): array => awaitAll(array_map(
-            static fn (string $url) => $client->getAsync($url),
-            $urls,
-        )));
+        try {
+            $scheduler = new Scheduler();
+            $client    = new AsyncHttpClient($scheduler);
+            $bodies = $scheduler->run(static fn (): array => awaitAll(array_map(
+                static fn (string $url) => $client->getAsync($url),
+                $urls,
+            )));
+        } catch (\Throwable) {
+            foreach ($urls as $key => $_) {
+                $bodies[$key] = '';
+            }
+        }
     }
     $wallClockMs = (hrtime(true) - $started) / 1e6;
 


### PR DESCRIPTION
### Motivation
- The `/dashboard/{id}` demo route could block PHP workers via three unbounded `file_get_contents()` calls in `sequential` mode and could let upstream cURL failures propagate as uncaught exceptions in `parallel` mode. 
- The intent is to keep the example runnable while bounding latency risk and preventing handler-level crashes from misbehaving backends.

### Description
- Added an explicit 5-second HTTP stream timeout for the sequential path using `stream_context_create` and passed it to `file_get_contents()`. 
- Normalized failed sequential fetches to empty strings instead of propagating `false` or relying on the global socket timeout. 
- Wrapped the parallel `Scheduler`/`awaitAll()` fan-out in a `try/catch` and populate backend entries with empty strings on any upstream failure to avoid uncaught exceptions. 
- Initialized `$bodies = []` before the branch to ensure a consistent response shape regardless of failures.

### Testing
- Ran `php -l examples/products-api/public/index.php` and it returned `No syntax errors detected`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f695699b7c832f9243e8a926c4ed0e)