### PR TITLE
Binder: fall back to eval when validator attribute args can't be dumped

### DIFF
--- a/src/Rxn/Framework/Http/Binding/Binder.php
+++ b/src/Rxn/Framework/Http/Binding/Binder.php
@@ -232,7 +232,10 @@ final class Binder
         $closureBody = "return static function (array \$bag) use (\$validators, \$dtoFactory): \\" . ltrim($class, '\\')
                      . " {\n" . $body . "};";
 
-        if (\Rxn\Framework\Codegen\DumpCache::dir() !== null) {
+        if (
+            \Rxn\Framework\Codegen\DumpCache::dir() !== null
+            && count($validatorExprs) === count($validators)
+        ) {
             // Dump path: prepend $validators and a serialisable
             // $dtoFactory so the file is self-contained when
             // `require`d. The closure's `use ($validators, $dtoFactory)`
@@ -309,7 +312,15 @@ final class Binder
             if (is_subclass_of($attrName, Validates::class) || in_array(Validates::class, class_implements($attrName) ?: [], true)) {
                 $instance = $attr->newInstance();
                 $idx = array_push($validators, $instance) - 1;
-                $validatorExprs[$idx] = self::validatorConstructionExpr($attrName, $attr->getArguments());
+                $expr = self::validatorConstructionExpr($attrName, $attr->getArguments());
+                if ($expr === null) {
+                    // Attribute args include values we can't safely
+                    // render into dump source (e.g. object-valued
+                    // constructor expressions). Force eval path.
+                    $validatorExprs = [];
+                } elseif ($validatorExprs !== []) {
+                    $validatorExprs[$idx] = $expr;
+                }
                 $validateBlock .= "        \$msg = \$validators[$idx]->validate(\$cast);\n"
                                .  "        if (\$msg !== null) { \$errors[] = ['field' => $nameQ, 'message' => \$msg]; }\n";
             }
@@ -559,14 +570,36 @@ final class Binder
      *
      * @param array<int|string, mixed> $args from `ReflectionAttribute::getArguments()`
      */
-    private static function validatorConstructionExpr(string $class, array $args): string
+    private static function validatorConstructionExpr(string $class, array $args): ?string
     {
         $parts = [];
         foreach ($args as $key => $val) {
+            if (!self::isDumpableAttributeArg($val)) {
+                return null;
+            }
             $literal = var_export($val, true);
             $parts[] = is_string($key) ? "$key: $literal" : $literal;
         }
         return 'new \\' . ltrim($class, '\\') . '(' . implode(', ', $parts) . ')';
+    }
+
+    private static function isDumpableAttributeArg(mixed $value): bool
+    {
+        if (is_null($value) || is_scalar($value)) {
+            return true;
+        }
+        if (is_array($value)) {
+            foreach ($value as $item) {
+                if (!self::isDumpableAttributeArg($item)) {
+                    return false;
+                }
+            }
+            return true;
+        }
+        // Objects can be valid at runtime attribute construction
+        // time, but `var_export()` may emit `__set_state` calls
+        // that are not supported by arbitrary classes.
+        return false;
     }
 
     private static function ensureIdentifier(string $name): string

--- a/src/Rxn/Framework/Http/Binding/Binder.php
+++ b/src/Rxn/Framework/Http/Binding/Binder.php
@@ -599,9 +599,13 @@ final class Binder
             }
             return true;
         }
-        // Objects can be valid at runtime attribute construction
-        // time, but `var_export()` may emit `__set_state` calls
-        // that are not supported by arbitrary classes.
+        // Enum cases (UnitEnum / BackedEnum) are safely round-tripped
+        // by `var_export()` as `\Ns\EnumClass::CaseName`.
+        if ($value instanceof \UnitEnum) {
+            return true;
+        }
+        // Arbitrary objects may emit `__set_state` calls via
+        // `var_export()` that are not supported by most classes.
         return false;
     }
 

--- a/src/Rxn/Framework/Http/Binding/Binder.php
+++ b/src/Rxn/Framework/Http/Binding/Binder.php
@@ -234,6 +234,7 @@ final class Binder
 
         if (
             \Rxn\Framework\Codegen\DumpCache::dir() !== null
+            && $validatorExprs !== null
             && count($validatorExprs) === count($validators)
         ) {
             // Dump path: prepend $validators and a serialisable
@@ -260,13 +261,14 @@ final class Binder
      * Generate the PHP fragment that hydrates and validates one
      * property of the DTO.
      *
-     * @param array<int, object> $validators     instances side-table for the eval path
-     * @param array<int, string> $validatorExprs construction-expression side-table for the dump path
+     * @param array<int, object>  $validators     instances side-table for the eval path
+     * @param ?array<int, string> $validatorExprs construction-expression side-table for the dump path;
+     *                                            null means "force eval path" (an undumpable arg was found)
      */
     private static function compileProperty(
         \ReflectionProperty $prop,
         array &$validators,
-        array &$validatorExprs,
+        ?array &$validatorExprs,
     ): string {
         $name   = $prop->getName();
         $nameQ  = self::quoteString($name);
@@ -317,8 +319,8 @@ final class Binder
                     // Attribute args include values we can't safely
                     // render into dump source (e.g. object-valued
                     // constructor expressions). Force eval path.
-                    $validatorExprs = [];
-                } elseif ($validatorExprs !== []) {
+                    $validatorExprs = null;
+                } elseif ($validatorExprs !== null) {
                     $validatorExprs[$idx] = $expr;
                 }
                 $validateBlock .= "        \$msg = \$validators[$idx]->validate(\$cast);\n"
@@ -555,10 +557,10 @@ final class Binder
 
     /**
      * Render a `new \Foo\Bar(arg, ...)` expression for the dump
-     * path's `$validators = [...]` prelude. Attribute arguments
-     * are restricted by PHP to const expressions (scalars, enum
-     * cases, class constants, arrays of those), all of which
-     * `var_export` round-trips correctly.
+     * path's `$validators = [...]` prelude. Returns `null` when
+     * any argument is not safely renderable (e.g. object-valued
+     * constructor args that would require `__set_state` support),
+     * signalling to the caller that the dump path must be skipped.
      *
      * Handles three argument shapes:
      *   - all positional: `new Foo('US', 1)`
@@ -569,6 +571,7 @@ final class Binder
      *                     `name: value` and positional bare.
      *
      * @param array<int|string, mixed> $args from `ReflectionAttribute::getArguments()`
+     * @return string|null construction expression, or null if args are not safely dumpable
      */
     private static function validatorConstructionExpr(string $class, array $args): ?string
     {

--- a/src/Rxn/Framework/Http/Binding/Binder.php
+++ b/src/Rxn/Framework/Http/Binding/Binder.php
@@ -586,6 +586,25 @@ final class Binder
         return 'new \\' . ltrim($class, '\\') . '(' . implode(', ', $parts) . ')';
     }
 
+    /**
+     * Decide whether `$value` can survive a `var_export()` round-trip
+     * for inclusion in the dump-cache file.
+     *
+     * Safe shapes:
+     *   - null, scalars (string/int/float/bool)
+     *   - arrays whose every element recursively passes
+     *   - UnitEnum / BackedEnum cases (rendered as `\Ns\Enum::CASE`)
+     *
+     * Unsafe shapes — these force the dump path to be skipped and
+     * the eval path to be taken instead:
+     *   - generic objects (var_export emits `__set_state`, which
+     *     most classes don't implement)
+     *   - resources, closures
+     *
+     * Falling back to eval is correct (the validator still runs;
+     * see `testCompileForFallsBackToEvalWhenValidatorArgsContainObjects`)
+     * — it just forfeits the dump-cache speedup.
+     */
     private static function isDumpableAttributeArg(mixed $value): bool
     {
         if (is_null($value) || is_scalar($value)) {
@@ -599,13 +618,9 @@ final class Binder
             }
             return true;
         }
-        // Enum cases (UnitEnum / BackedEnum) are safely round-tripped
-        // by `var_export()` as `\Ns\EnumClass::CaseName`.
         if ($value instanceof \UnitEnum) {
             return true;
         }
-        // Arbitrary objects may emit `__set_state` calls via
-        // `var_export()` that are not supported by most classes.
         return false;
     }
 

--- a/src/Rxn/Framework/Tests/Http/Binding/BinderTest.php
+++ b/src/Rxn/Framework/Tests/Http/Binding/BinderTest.php
@@ -8,6 +8,7 @@ use Rxn\Framework\Http\Binding\Binder;
 use Rxn\Framework\Http\Binding\ValidationException;
 use Rxn\Framework\Tests\Http\Binding\Fixture\Address;
 use Rxn\Framework\Tests\Http\Binding\Fixture\CreateProduct;
+use Rxn\Framework\Tests\Http\Binding\Fixture\ObjectArgDto;
 
 final class BinderTest extends TestCase
 {
@@ -473,6 +474,20 @@ final class BinderTest extends TestCase
         $this->assertEmpty(
             glob($this->dumpDir . '/*.php') ?: [],
             'no files should land in the dump dir when DumpCache is not configured',
+        );
+    }
+
+    public function testCompileForFallsBackToEvalWhenValidatorArgsContainObjects(): void
+    {
+        DumpCache::useDir($this->dumpDir);
+        Binder::clearCache();
+
+        $bind = Binder::compileFor(ObjectArgDto::class);
+        $dto = $bind(['code' => 'ok']);
+        $this->assertSame('ok', $dto->code);
+        $this->assertEmpty(
+            glob($this->dumpDir . '/*.php') ?: [],
+            'object-valued validator args should bypass dump generation',
         );
     }
 }

--- a/src/Rxn/Framework/Tests/Http/Binding/BinderTest.php
+++ b/src/Rxn/Framework/Tests/Http/Binding/BinderTest.php
@@ -483,11 +483,29 @@ final class BinderTest extends TestCase
         Binder::clearCache();
 
         $bind = Binder::compileFor(ObjectArgDto::class);
+
+        // Happy path: validator passes, DTO hydrates.
         $dto = $bind(['code' => 'ok']);
         $this->assertSame('ok', $dto->code);
+
+        // No dump file written — the eval-only fallback skipped it.
         $this->assertEmpty(
             glob($this->dumpDir . '/*.php') ?: [],
             'object-valued validator args should bypass dump generation',
         );
+
+        // Crucially: the validator itself must still run on the eval
+        // fallback path. If a future refactor accidentally bypassed
+        // it, this assertion fails — happy-path-only coverage would
+        // miss that regression.
+        try {
+            $bind(['code' => 'wrong']);
+            $this->fail('expected ValidationException — validator was bypassed on eval fallback');
+        } catch (ValidationException $e) {
+            $errors = $e->errors();
+            $this->assertCount(1, $errors);
+            $this->assertSame('code', $errors[0]['field']);
+            $this->assertSame('must match expected', $errors[0]['message']);
+        }
     }
 }

--- a/src/Rxn/Framework/Tests/Http/Binding/Fixture/ObjectArgDto.php
+++ b/src/Rxn/Framework/Tests/Http/Binding/Fixture/ObjectArgDto.php
@@ -1,0 +1,12 @@
+<?php declare(strict_types=1);
+
+namespace Rxn\Framework\Tests\Http\Binding\Fixture;
+
+use Rxn\Framework\Http\Attribute\Required;
+
+final class ObjectArgDto
+{
+    #[Required]
+    #[ObjectArgValidator(new RuleObj('ok'))]
+    public string $code;
+}

--- a/src/Rxn/Framework/Tests/Http/Binding/Fixture/ObjectArgDto.php
+++ b/src/Rxn/Framework/Tests/Http/Binding/Fixture/ObjectArgDto.php
@@ -3,8 +3,9 @@
 namespace Rxn\Framework\Tests\Http\Binding\Fixture;
 
 use Rxn\Framework\Http\Attribute\Required;
+use Rxn\Framework\Http\Binding\RequestDto;
 
-final class ObjectArgDto
+final class ObjectArgDto implements RequestDto
 {
     #[Required]
     #[ObjectArgValidator(new RuleObj('ok'))]

--- a/src/Rxn/Framework/Tests/Http/Binding/Fixture/ObjectArgValidator.php
+++ b/src/Rxn/Framework/Tests/Http/Binding/Fixture/ObjectArgValidator.php
@@ -1,0 +1,16 @@
+<?php declare(strict_types=1);
+
+namespace Rxn\Framework\Tests\Http\Binding\Fixture;
+
+use Rxn\Framework\Http\Binding\Validates;
+
+#[\Attribute(\Attribute::TARGET_PROPERTY)]
+final class ObjectArgValidator implements Validates
+{
+    public function __construct(private readonly RuleObj $rule) {}
+
+    public function validate(mixed $value): ?string
+    {
+        return $value === $this->rule->expected ? null : 'must match expected';
+    }
+}

--- a/src/Rxn/Framework/Tests/Http/Binding/Fixture/RuleObj.php
+++ b/src/Rxn/Framework/Tests/Http/Binding/Fixture/RuleObj.php
@@ -1,0 +1,8 @@
+<?php declare(strict_types=1);
+
+namespace Rxn\Framework\Tests\Http\Binding\Fixture;
+
+final class RuleObj
+{
+    public function __construct(public readonly string $expected) {}
+}


### PR DESCRIPTION
### Motivation
- The dump-cache path for `Binder::compileFor()` serialized validator constructor args with `var_export()` which can emit `Class::__set_state(...)` for object-valued attribute args and crash when the generated PHP file is `require`d.
- The change must avoid producing crash-prone dump files while preserving the existing eval-compiled behavior for cases that cannot be safely rendered.

### Description
- Make `validatorConstructionExpr()` return `?string` and add `isDumpableAttributeArg()` to allow only `null`/scalar/array-of-allowed-values when rendering validator constructor args for the dump prelude.
- When an attribute's args are not dumpable the code clears the `validatorExprs` side-table to force the eval path and prevent on-disk dump generation. 
- Only use the dump path when `DumpCache::dir()` is set and `count($validatorExprs) === count($validators)` to ensure all validators have safe construction expressions. 
- Add regression fixtures `ObjectArgDto`, `ObjectArgValidator`, and `RuleObj` plus a unit test `testCompileForFallsBackToEvalWhenValidatorArgsContainObjects()` that asserts `compileFor()` still runs but does not write a dump file when validator args contain objects.

### Testing
- Static syntax checks with `php -l` were run on modified source and new fixture/test files and all reported "No syntax errors detected". 
- Attempted to run PHPUnit (`composer test` / vendor phpunit) but the `phpunit` executable is not installed in the environment so full test-suite execution could not be performed. 
- Changes were committed on the branch and the PR prepared; the fix is minimal and targets only the dump-generation path so runtime `Binder::bind()` behavior is unchanged.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f69568c318832f8feaf60feb766952)