### PR TITLE
Refuse unhandled `Validates` attributes in JS validator emitter

### DIFF
--- a/src/Rxn/Framework/Codegen/JsValidatorEmitter.php
+++ b/src/Rxn/Framework/Codegen/JsValidatorEmitter.php
@@ -11,6 +11,7 @@ use Rxn\Framework\Http\Attribute\Required;
 use Rxn\Framework\Http\Attribute\Url;
 use Rxn\Framework\Http\Attribute\Email;
 use Rxn\Framework\Http\Binding\RequestDto;
+use Rxn\Framework\Http\Binding\Validates;
 
 /**
  * Emit a vanilla ES module that validates an input object against
@@ -207,14 +208,13 @@ final class JsValidatorEmitter
     private function refuse(string $attrName): string
     {
         // Generic / non-Validates attributes: ignore (the runtime
-        // walker also skips them). Only refuse known-Validates
-        // attributes we haven't implemented yet — those would be
-        // silent divergences.
-        $known = ['Pattern', 'Uuid', 'Json', 'Date', 'StartsWith', 'EndsWith'];
-        $short = (new \ReflectionClass($attrName))->getShortName();
-        if (in_array($short, $known, true)) {
+        // walker also skips them). Refuse every Validates
+        // implementation we cannot mirror — silent divergence
+        // between generated JS and Binder is the worst failure mode.
+        $ref = new \ReflectionClass($attrName);
+        if ($ref->implementsInterface(Validates::class)) {
             throw new \RuntimeException(
-                "JsValidatorEmitter: $attrName is a known validator but has no JS twin yet. "
+                "JsValidatorEmitter: $attrName implements " . Validates::class . " but has no JS twin yet. "
                 . "Refusing to emit silently-divergent code. "
                 . "Add an emit method or document the DTO as PHP-only.",
             );

--- a/src/Rxn/Framework/Tests/Codegen/Fixture/CustomUnsupportedDto.php
+++ b/src/Rxn/Framework/Tests/Codegen/Fixture/CustomUnsupportedDto.php
@@ -1,0 +1,13 @@
+<?php declare(strict_types=1);
+
+namespace Rxn\Framework\Tests\Codegen\Fixture;
+
+use Rxn\Framework\Http\Attribute\Required;
+use Rxn\Framework\Http\Binding\RequestDto;
+
+final class CustomUnsupportedDto implements RequestDto
+{
+    #[Required]
+    #[CustomValidatesAttribute]
+    public string $token;
+}

--- a/src/Rxn/Framework/Tests/Codegen/Fixture/CustomValidatesAttribute.php
+++ b/src/Rxn/Framework/Tests/Codegen/Fixture/CustomValidatesAttribute.php
@@ -1,0 +1,15 @@
+<?php declare(strict_types=1);
+
+namespace Rxn\Framework\Tests\Codegen\Fixture;
+
+use Attribute;
+use Rxn\Framework\Http\Binding\Validates;
+
+#[Attribute(Attribute::TARGET_PROPERTY)]
+final class CustomValidatesAttribute implements Validates
+{
+    public function validate(mixed $value): ?string
+    {
+        return null;
+    }
+}

--- a/src/Rxn/Framework/Tests/Codegen/JsValidatorParityTest.php
+++ b/src/Rxn/Framework/Tests/Codegen/JsValidatorParityTest.php
@@ -54,6 +54,15 @@ final class JsValidatorParityTest extends TestCase
         $this->assertSame(0, $result->disagreements, $result->describe());
     }
 
+
+    public function testEmitterRefusesCustomValidatesAttribute(): void
+    {
+        $emitter = new JsValidatorEmitter();
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessageMatches('/implements.*Validates.*no JS twin/i');
+        $emitter->emit(Fixture\CustomUnsupportedDto::class);
+    }
+
     public function testEmitterRefusesUnsupportedAttribute(): void
     {
         $emitter = new JsValidatorEmitter();


### PR DESCRIPTION
### Motivation
- The JS emitter previously sent unknown attributes to `refuse()` which returned an empty string for custom validators, allowing application-defined `Validates` implementations to be omitted from generated JS and causing client/server validation drift. 
- The goal is to ensure the emitter preserves the documented safety property by refusing any attribute that implements `Rxn\Framework\Http\Binding\Validates` when no JS twin exists.

### Description
- Updated `src/Rxn/Framework/Codegen/JsValidatorEmitter.php` to `use Rxn\Framework\Http\Binding\Validates` and changed `refuse()` to reflect on the attribute class and throw a `RuntimeException` if it implements `Validates`, while still ignoring non-validator attributes. 
- Kept existing built-in emitter behavior for known attributes handled by `emitInline()`. 
- Added regression fixture `src/Rxn/Framework/Tests/Codegen/Fixture/CustomValidatesAttribute.php` implementing `Validates` and `src/Rxn/Framework/Tests/Codegen/Fixture/CustomUnsupportedDto.php` that uses it. 
- Added a unit test `testEmitterRefusesCustomValidatesAttribute` to `src/Rxn/Framework/Tests/Codegen/JsValidatorParityTest.php` asserting the emitter throws for a custom `Validates` attribute without a JS twin.

### Testing
- Added automated test coverage via the new `testEmitterRefusesCustomValidatesAttribute` in `JsValidatorParityTest` which asserts a `RuntimeException` is thrown for custom `Validates` attributes. 
- Attempted to run the targeted PHPUnit invocation (`phpunit src/Rxn/Framework/Tests/Codegen/JsValidatorParityTest.php` and `./vendor/bin/phpunit ...`) but the test runner is not available in this environment so execution could not be completed. 
- The parity harness test already guards for `node` availability and will skip cross-language runs when `node` is not on PATH, so full parity runs require `node` and a PHPUnit environment to verify end-to-end behavior.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f6956aff14832fa7fd57e40d8ad350)