### PR TITLE
fix(container): make has() reject unautowireable classes

### DIFF
--- a/src/Rxn/Framework/Container.php
+++ b/src/Rxn/Framework/Container.php
@@ -486,6 +486,10 @@ class Container implements ContainerInterface
                         return false;
                     }
                     break;
+                default:
+                    // 'default' and 'null' directives don't prevent
+                    // construction; intentionally skip them.
+                    break;
             }
         }
 

--- a/src/Rxn/Framework/Container.php
+++ b/src/Rxn/Framework/Container.php
@@ -412,7 +412,8 @@ class Container implements ContainerInterface
      *
      * Rxn's container autowires any constructible class, so for a
      * class-string identifier this is equivalent to "class exists,
-     * isn't abstract, and isn't already failing as a binding."
+     * is instantiable (not abstract/interface/trait/non-public constructor),
+     * and has no required non-autowireable constructor parameters."
      * We also short-circuit on the self-lookup key, declared
      * bindings, and the instance cache so the lookup is O(1) for
      * the hot paths.
@@ -437,8 +438,13 @@ class Container implements ContainerInterface
             return false;
         }
 
+        // Canonicalise to the declared class casing so process-lifetime
+        // caches don't grow with case-variant aliases of the same class
+        // (mirrors the normalisation that get() applies).
+        $class_name = $this->parseClassName(self::reflectionFor($class_name)->getName());
+
         $reflection = self::reflectionFor($class_name);
-        if ($reflection->isAbstract()) {
+        if (!$reflection->isInstantiable()) {
             return false;
         }
 

--- a/src/Rxn/Framework/Container.php
+++ b/src/Rxn/Framework/Container.php
@@ -436,10 +436,24 @@ class Container implements ContainerInterface
         if (!class_exists($class_name)) {
             return false;
         }
-        // Abstract classes satisfy class_exists() but cannot be
-        // instantiated by the autowirer, so get() would throw.
-        // has() must only return true when get() would succeed.
-        return !self::reflectionFor($class_name)->isAbstract();
+
+        $reflection = self::reflectionFor($class_name);
+        if ($reflection->isAbstract()) {
+            return false;
+        }
+
+        $plan = self::constructorPlanFor($class_name);
+        if ($plan === null) {
+            return true;
+        }
+
+        foreach ($plan as $directive) {
+            if ($directive[0] === 'fail') {
+                return false;
+            }
+        }
+
+        return true;
     }
 
     private function parseClassName($class_name)

--- a/src/Rxn/Framework/Container.php
+++ b/src/Rxn/Framework/Container.php
@@ -410,19 +410,34 @@ class Container implements ContainerInterface
      * PSR-11 `has()`: return true iff `get($id)` would resolve
      * without throwing.
      *
-     * Rxn's container autowires any constructible class, so for a
-     * class-string identifier this is equivalent to "class exists,
-     * is instantiable (not abstract/interface/trait/non-public constructor),
-     * and has no required non-autowireable constructor parameters."
-     * We also short-circuit on the self-lookup key, declared
-     * bindings, and the instance cache so the lookup is O(1) for
-     * the hot paths.
+     * Rxn's container autowires any constructible class. This
+     * check verifies that the class exists, is instantiable
+     * (not abstract/interface/trait/non-public constructor),
+     * has no required non-autowireable constructor parameters,
+     * and that all autowired constructor dependencies are
+     * themselves resolvable (checked recursively to catch
+     * unbound interface/abstract dependencies).
      *
-     * Doesn't catch circular-dependency failures — those are
-     * detectable only at construction time. PSR-11 explicitly
-     * permits this.
+     * Fast paths: self-lookup, declared bindings, and cached
+     * instances short-circuit to true without further checking.
+     *
+     * Circular dependencies that pass through a binding or
+     * cached instance are not caught — those are only detectable
+     * at construction time. PSR-11 explicitly permits this.
      */
     public function has(string $id): bool
+    {
+        return $this->canResolve($id, []);
+    }
+
+    /**
+     * Internal recursive implementation of `has()`.
+     *
+     * @param array<string, true> $visited  Canonical class names already
+     *                                       in the current resolution chain,
+     *                                       used for cycle detection.
+     */
+    private function canResolve(string $id, array $visited): bool
     {
         $class_name = $this->parseClassName($id);
         if ($class_name === self::SELF_KEY) {
@@ -438,10 +453,16 @@ class Container implements ContainerInterface
             return false;
         }
 
-        // Canonicalise to the declared class casing so process-lifetime
-        // caches don't grow with case-variant aliases of the same class
-        // (mirrors the normalisation that get() applies).
-        $class_name = $this->parseClassName(self::reflectionFor($class_name)->getName());
+        // Canonicalise to the declared class casing using a one-shot
+        // ReflectionClass so the reflectionFor() cache is only populated
+        // under the canonical key, not a case-variant alias key.
+        $class_name = $this->parseClassName((new \ReflectionClass($class_name))->getName());
+
+        // Cycle detection: if this class is already in the current
+        // resolution chain, get() would throw a circular-dependency error.
+        if (isset($visited[$class_name])) {
+            return false;
+        }
 
         $reflection = self::reflectionFor($class_name);
         if (!$reflection->isInstantiable()) {
@@ -453,9 +474,18 @@ class Container implements ContainerInterface
             return true;
         }
 
+        // Mark this class as in-progress before recursing so that
+        // transitive dependencies looping back here are caught.
+        $visited[$class_name] = true;
         foreach ($plan as $directive) {
-            if ($directive[0] === 'fail') {
-                return false;
+            switch ($directive[0]) {
+                case 'fail':
+                    return false;
+                case 'autowire':
+                    if (!$this->canResolve($directive[1], $visited)) {
+                        return false;
+                    }
+                    break;
             }
         }
 

--- a/src/Rxn/Framework/Tests/ContainerTest.php
+++ b/src/Rxn/Framework/Tests/ContainerTest.php
@@ -12,6 +12,7 @@ use Rxn\Framework\Tests\Fixture\Container\Timestamper;
 use Rxn\Framework\Tests\Fixture\Container\UserRepo;
 use Rxn\Framework\Tests\Fixture\Container\MemoryUserRepo;
 use Rxn\Framework\Tests\Fixture\Container\NeedsDefaultBag;
+use Rxn\Framework\Utility\Logger;
 
 final class ContainerTest extends TestCase
 {
@@ -120,6 +121,13 @@ final class ContainerTest extends TestCase
     {
         $c = new Container();
         $this->assertFalse($c->has('Definitely\\Not\\A\\Real\\ClassName'));
+    }
+
+
+    public function testHasReturnsFalseForClassWithRequiredScalarConstructorParameter(): void
+    {
+        $c = new Container();
+        $this->assertFalse($c->has(Logger::class));
     }
 
     public function testHasReturnsFalseForAbstractClass(): void

--- a/src/Rxn/Framework/Tests/ContainerTest.php
+++ b/src/Rxn/Framework/Tests/ContainerTest.php
@@ -130,6 +130,18 @@ final class ContainerTest extends TestCase
         $this->assertFalse($c->has(Logger::class));
     }
 
+    public function testHasReturnsFalseForUnboundInterfaceDependency(): void
+    {
+        // Timestamper's constructor requires Clock (an unbound interface).
+        // get(Timestamper) would throw, so has() must return false.
+        $c = new Container();
+        $this->assertFalse($c->has(Timestamper::class), 'unbound interface dep must make has() return false');
+
+        // Once Clock is bound, the dependency is resolvable and has() returns true.
+        $c->bind(Clock::class, SystemClock::class);
+        $this->assertTrue($c->has(Timestamper::class), 'bound dep must allow has() to return true');
+    }
+
     public function testHasReturnsFalseForAbstractClass(): void
     {
         // PSR-11: has() must return false when get() would fail.


### PR DESCRIPTION
### Motivation
- `Container::has()` previously returned true for any existing class (via `class_exists()`), which could be false-positive when `get()` would fail due to required non-autowireable constructor parameters, violating the PSR-11 expectation that `has($id)` is a safe preflight for `get($id)`. 
- This mismatch can cause callers that rely on `has()` to attempt `get()` and receive `ContainerException` or `Error` instead of a predictable false result.

### Description
- Change `Container::has()` to, after the existing self/binding/instance fast paths and `class_exists()` check, obtain a `ReflectionClass`, reject abstract classes, and consult `constructorPlanFor()` to ensure no `['fail', ...]` directives are present before returning true. 
- Preserve fast-path behavior for the self key, declared bindings, and cached instances so hot paths remain O(1). 
- Add a regression test `testHasReturnsFalseForClassWithRequiredScalarConstructorParameter()` (uses `Rxn\Framework\Utility\Logger`) to assert `has()` returns `false` when a required scalar constructor parameter prevents autowiring. 

### Testing
- Ran PHP syntax checks with `php -l src/Rxn/Framework/Container.php` and `php -l src/Rxn/Framework/Tests/ContainerTest.php`, both of which reported no syntax errors. 
- Added the unit test that reproduces the has/get mismatch and verifies the corrected behavior (`testHasReturnsFalseForClassWithRequiredScalarConstructorParameter`). 
- Attempted to run PHPUnit but `vendor/bin/phpunit` and global `phpunit` are not available in this environment, so full test-suite execution could not be performed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f69568b8ac832fa2e5c09d17e38406)