### PR TITLE
fix(bench): reject non-finite product prices in psr7 app

### DIFF
--- a/bench/compare/apps/rxn-psr7/public/index.php
+++ b/bench/compare/apps/rxn-psr7/public/index.php
@@ -91,7 +91,7 @@ $terminal = new class ($router) implements RequestHandlerInterface {
         }
 
         if (!is_finite($dto->price)) {
-            return $this->problem(422, 'Validation failed', ['price' => ['must be a finite number']]);
+            return $this->problem(422, 'Validation failed', [['field' => 'price', 'message' => 'must be a finite number']]);
         }
 
         return $this->json(

--- a/bench/compare/apps/rxn-psr7/public/index.php
+++ b/bench/compare/apps/rxn-psr7/public/index.php
@@ -90,6 +90,10 @@ $terminal = new class ($router) implements RequestHandlerInterface {
             return $this->problem(422, 'Validation failed', $e->errors());
         }
 
+        if (!is_finite($dto->price)) {
+            return $this->problem(422, 'Validation failed', ['price' => ['must be a finite number']]);
+        }
+
         return $this->json(
             201,
             json_encode(['id' => 1, 'name' => $dto->name, 'price' => $dto->price]),


### PR DESCRIPTION
### Motivation
- Prevent a 500 crash in the PSR-7 benchmark `createProduct()` route when a bound `price` becomes non-finite (e.g. `INF` from an overflowing JSON number) which causes `json_encode()` to return `false` and triggers a `TypeError` when passed to the string-typed response helper.

### Description
- Add a minimal guard in `bench/compare/apps/rxn-psr7/public/index.php`'s `createProduct()` that returns a `422` problem response if `!is_finite($dto->price)`, avoiding downstream `json_encode()` failure and preserving existing benchmark behavior elsewhere.

### Testing
- Ran PHP lint on the modified file with `php -l bench/compare/apps/rxn-psr7/public/index.php`, which reported no syntax errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f69569e930832fb4660a54e8a368cc)