### PR TITLE
fix(concurrency): restrict async HttpClient to http/https schemes

### DIFF
--- a/src/Rxn/Framework/Concurrency/HttpClient.php
+++ b/src/Rxn/Framework/Concurrency/HttpClient.php
@@ -35,6 +35,11 @@ final class HttpClient
      */
     public function getAsync(string $url, array $headers = []): Promise
     {
+        $scheme = strtolower((string) parse_url($url, PHP_URL_SCHEME));
+        if ($scheme !== 'http' && $scheme !== 'https') {
+            throw new \InvalidArgumentException('Only http/https URLs are allowed.');
+        }
+
         $handle = curl_init();
         curl_setopt_array($handle, [
             CURLOPT_URL            => $url,
@@ -42,6 +47,8 @@ final class HttpClient
             CURLOPT_HTTPHEADER     => $this->headerLines($headers),
             CURLOPT_TIMEOUT_MS     => $this->timeoutMs,
             CURLOPT_CONNECTTIMEOUT_MS => $this->timeoutMs,
+            CURLOPT_PROTOCOLS      => CURLPROTO_HTTP | CURLPROTO_HTTPS,
+            CURLOPT_REDIR_PROTOCOLS => CURLPROTO_HTTP | CURLPROTO_HTTPS,
         ]);
         return $this->scheduler->submitCurl($handle);
     }

--- a/src/Rxn/Framework/Concurrency/HttpClient.php
+++ b/src/Rxn/Framework/Concurrency/HttpClient.php
@@ -41,15 +41,27 @@ final class HttpClient
         }
 
         $handle = curl_init();
-        curl_setopt_array($handle, [
+        $opts = [
             CURLOPT_URL            => $url,
             CURLOPT_RETURNTRANSFER => true,
             CURLOPT_HTTPHEADER     => $this->headerLines($headers),
             CURLOPT_TIMEOUT_MS     => $this->timeoutMs,
             CURLOPT_CONNECTTIMEOUT_MS => $this->timeoutMs,
-            CURLOPT_PROTOCOLS      => CURLPROTO_HTTP | CURLPROTO_HTTPS,
-            CURLOPT_REDIR_PROTOCOLS => CURLPROTO_HTTP | CURLPROTO_HTTPS,
-        ]);
+        ];
+        // CURLOPT_PROTOCOLS / CURLPROTO_* are not guaranteed on every libcurl build;
+        // guard with defined() to avoid a fatal error when the constants are absent.
+        // The parse_url() scheme check above is the primary security guard; these
+        // curl options are an additional defence-in-depth layer only.
+        if (
+            defined('CURLOPT_PROTOCOLS')
+            && defined('CURLOPT_REDIR_PROTOCOLS')
+            && defined('CURLPROTO_HTTP')
+            && defined('CURLPROTO_HTTPS')
+        ) {
+            $opts[CURLOPT_PROTOCOLS]       = CURLPROTO_HTTP | CURLPROTO_HTTPS;
+            $opts[CURLOPT_REDIR_PROTOCOLS] = CURLPROTO_HTTP | CURLPROTO_HTTPS;
+        }
+        curl_setopt_array($handle, $opts);
         return $this->scheduler->submitCurl($handle);
     }
 

--- a/src/Rxn/Framework/Tests/Concurrency/HttpClientTest.php
+++ b/src/Rxn/Framework/Tests/Concurrency/HttpClientTest.php
@@ -1,0 +1,65 @@
+<?php declare(strict_types=1);
+
+namespace Rxn\Framework\Tests\Concurrency;
+
+use PHPUnit\Framework\TestCase;
+use Rxn\Framework\Concurrency\HttpClient;
+use Rxn\Framework\Concurrency\Scheduler;
+
+/**
+ * Unit tests for `HttpClient` that don't require live HTTP.
+ *
+ * The happy path (real GET against a real server) is covered by
+ * `bench/fiber/run.php` which boots backends; here we lock the
+ * scheme-rejection guard so a `file://` / `gopher://` / `ftp://`
+ * URL never reaches `curl_init`.
+ */
+final class HttpClientTest extends TestCase
+{
+    public function testRejectsFileScheme(): void
+    {
+        // Scheme rejection runs *before* any curl call inside
+        // HttpClient::getAsync, so this test deliberately doesn't
+        // skip when ext-curl is missing — the guard is what's
+        // under test, and it must hold regardless.
+        $client = new HttpClient(new Scheduler());
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Only http/https URLs are allowed.');
+        $client->getAsync('file:///etc/hostname');
+    }
+
+    public function testRejectsGopherScheme(): void
+    {
+        $client = new HttpClient(new Scheduler());
+
+        $this->expectException(\InvalidArgumentException::class);
+        $client->getAsync('gopher://example.com/');
+    }
+
+    public function testRejectsSchemelessUrl(): void
+    {
+        $client = new HttpClient(new Scheduler());
+
+        $this->expectException(\InvalidArgumentException::class);
+        $client->getAsync('example.com/path');
+    }
+
+    public function testAcceptsHttpAndHttpsButFailsLaterIfNoCurl(): void
+    {
+        // We only assert the guard is silent for http/https; the
+        // call may then fail on missing curl or network — those
+        // are out of scope for this test.
+        $client = new HttpClient(new Scheduler());
+
+        if (!extension_loaded('curl')) {
+            $this->markTestSkipped('ext-curl not available; cannot exercise the curl branch');
+        }
+
+        // No exception from the guard. Promise creation must not
+        // throw InvalidArgumentException for these URLs.
+        $client->getAsync('http://127.0.0.1:1/will-not-resolve');
+        $client->getAsync('https://127.0.0.1:1/will-not-resolve');
+        $this->assertTrue(true, 'http/https URLs pass the scheme guard');
+    }
+}

--- a/src/Rxn/Framework/Tests/Concurrency/SchedulerTest.php
+++ b/src/Rxn/Framework/Tests/Concurrency/SchedulerTest.php
@@ -3,6 +3,7 @@
 namespace Rxn\Framework\Tests\Concurrency;
 
 use PHPUnit\Framework\TestCase;
+use Rxn\Framework\Concurrency\HttpClient;
 use Rxn\Framework\Concurrency\Promise;
 use Rxn\Framework\Concurrency\Scheduler;
 
@@ -152,6 +153,16 @@ final class SchedulerTest extends TestCase
         $scheduler->run(fn () => awaitAny([$a, $b]));
     }
 
+
+    public function testHttpClientRejectsNonHttpSchemes(): void
+    {
+        $scheduler = new Scheduler();
+        $client = new HttpClient($scheduler);
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Only http/https URLs are allowed.');
+        $client->getAsync('file:///etc/hostname');
+    }
     public function testPromiseDoubleSettleThrows(): void
     {
         $scheduler = new Scheduler();

--- a/src/Rxn/Framework/Tests/Concurrency/SchedulerTest.php
+++ b/src/Rxn/Framework/Tests/Concurrency/SchedulerTest.php
@@ -156,6 +156,10 @@ final class SchedulerTest extends TestCase
 
     public function testHttpClientRejectsNonHttpSchemes(): void
     {
+        if (!extension_loaded('curl')) {
+            $this->markTestSkipped('ext-curl is not available.');
+        }
+
         $scheduler = new Scheduler();
         $client = new HttpClient($scheduler);
 
@@ -163,6 +167,7 @@ final class SchedulerTest extends TestCase
         $this->expectExceptionMessage('Only http/https URLs are allowed.');
         $client->getAsync('file:///etc/hostname');
     }
+
     public function testPromiseDoubleSettleThrows(): void
     {
         $scheduler = new Scheduler();

--- a/src/Rxn/Framework/Tests/Concurrency/SchedulerTest.php
+++ b/src/Rxn/Framework/Tests/Concurrency/SchedulerTest.php
@@ -3,7 +3,6 @@
 namespace Rxn\Framework\Tests\Concurrency;
 
 use PHPUnit\Framework\TestCase;
-use Rxn\Framework\Concurrency\HttpClient;
 use Rxn\Framework\Concurrency\Promise;
 use Rxn\Framework\Concurrency\Scheduler;
 
@@ -151,21 +150,6 @@ final class SchedulerTest extends TestCase
         $this->expectException(\DomainException::class);
         $this->expectExceptionMessage('b');
         $scheduler->run(fn () => awaitAny([$a, $b]));
-    }
-
-
-    public function testHttpClientRejectsNonHttpSchemes(): void
-    {
-        if (!extension_loaded('curl')) {
-            $this->markTestSkipped('ext-curl is not available.');
-        }
-
-        $scheduler = new Scheduler();
-        $client = new HttpClient($scheduler);
-
-        $this->expectException(\InvalidArgumentException::class);
-        $this->expectExceptionMessage('Only http/https URLs are allowed.');
-        $client->getAsync('file:///etc/hostname');
     }
 
     public function testPromiseDoubleSettleThrows(): void


### PR DESCRIPTION
### Motivation
- The async `HttpClient` accepted caller-provided URLs and passed them directly to libcurl, exposing non-HTTP schemes (e.g. `file://`) and enabling local-file disclosure / SSRF. 
- The intent is to make the tiny HTTP client safe-by-default for typical HTTP usage while preserving the existing async/curl behavior for valid requests.

### Description
- Validate the request URL scheme in `HttpClient::getAsync()` using `parse_url()` and throw `InvalidArgumentException` for any scheme that is not `http` or `https` (file changed: `src/Rxn/Framework/Concurrency/HttpClient.php`).
- Add curl-level hardening by setting `CURLOPT_PROTOCOLS` and `CURLOPT_REDIR_PROTOCOLS` to `CURLPROTO_HTTP | CURLPROTO_HTTPS` so non-HTTP schemes are blocked even if input validation is bypassed (file changed: `src/Rxn/Framework/Concurrency/HttpClient.php`).
- Add a regression test `testHttpClientRejectsNonHttpSchemes` to `SchedulerTest` that asserts `file://` URLs are rejected (file changed: `src/Rxn/Framework/Tests/Concurrency/SchedulerTest.php`).

### Testing
- Ran syntax checks `php -l src/Rxn/Framework/Concurrency/HttpClient.php` and `php -l src/Rxn/Framework/Tests/Concurrency/SchedulerTest.php`, both of which succeeded. 
- Attempted to run the unit tests with `vendor/bin/phpunit src/Rxn/Framework/Tests/Concurrency/SchedulerTest.php` but the `phpunit` binary is not available in this environment, so the full test suite could not be executed here. 
- The added test is a pure-PHP unit that exercises `HttpClient::getAsync()` input validation and should pass when `phpunit` is run in a complete development environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f6b7ff8754832fad466754793d86cf)