### PR TITLE
fix(Codegen): PolyparityExporter follow-ups from PR #41 review

### DIFF
--- a/src/Rxn/Framework/Codegen/PolyparityExporter.php
+++ b/src/Rxn/Framework/Codegen/PolyparityExporter.php
@@ -161,6 +161,12 @@ final class PolyparityExporter
     }
 
     /**
+     * Read the numeric bound from a `#[Min]` / `#[Max]` attribute's
+     * raw `getArguments()` payload. Returns the bound as int|float,
+     * or throws a clear `RuntimeException` for any input shape Binder
+     * would also reject (so the exporter and the runtime stay aligned
+     * on what's a "valid" attribute usage).
+     *
      * @param array<int|string, mixed> $args
      */
     private function requireBound(array $args, string $key, string $attr, string $propName): int|float
@@ -176,6 +182,20 @@ final class PolyparityExporter
             throw new \RuntimeException(
                 "PolyparityExporter: $attr on property '$propName' has no value; "
                 . "attribute requires a numeric bound."
+            );
+        }
+        if (!is_int($value) && !is_float($value)) {
+            // Min/Max constructors are typed `int|float`. With
+            // strict_types in those files, PHP rejects non-numeric
+            // inputs (including numeric strings like '5') at
+            // newInstance() time. Mirror that here with a clearer
+            // exporter-side message rather than letting PHP raise
+            // a TypeError on this method's return type.
+            $type = get_debug_type($value);
+            throw new \RuntimeException(
+                "PolyparityExporter: $attr on property '$propName' "
+                . "must be int|float, got $type. "
+                . "Binder's attribute constructor would reject this too."
             );
         }
         return $value;

--- a/src/Rxn/Framework/Codegen/PolyparityExporter.php
+++ b/src/Rxn/Framework/Codegen/PolyparityExporter.php
@@ -62,10 +62,20 @@ final class PolyparityExporter
     {
         $name       = $prop->getName();
         $type       = $prop->getType();
-        $isRequired = $prop->getAttributes(Required::class) !== [];
         $allowsNull = $type instanceof \ReflectionNamedType && $type->allowsNull();
         $hasDefault = $prop->hasDefaultValue();
         $default    = $hasDefault ? $prop->getDefaultValue() : null;
+
+        // Required is effectively true in two cases:
+        //   1. Explicit #[Required] attribute on the property.
+        //   2. Non-nullable, no default — Binder::bind treats this
+        //      as required (see the missing-field branch: when the
+        //      property has neither a default nor a nullable type,
+        //      it adds an "is required" error).
+        // Mirror Binder semantics so the exported spec doesn't
+        // accept inputs the PHP server rejects.
+        $hasRequiredAttr = $prop->getAttributes(Required::class) !== [];
+        $isRequired      = $hasRequiredAttr || (!$allowsNull && !$hasDefault);
 
         $lines = [];
         $lines[] = '    ' . $name . ':';
@@ -77,7 +87,11 @@ final class PolyparityExporter
         if ($allowsNull) {
             $lines[] = '      nullable: true';
         }
-        if ($hasDefault && $default !== null) {
+        // Suppress `default:` when the field is required: Binder's
+        // missing-field branch fires "is required" before reaching
+        // the default-application path, so the default would be a
+        // misleading no-op in the spec.
+        if (!$isRequired && $hasDefault && $default !== null) {
             $lines[] = '      default: ' . $this->yamlScalar($default);
         }
 
@@ -136,14 +150,35 @@ final class PolyparityExporter
     {
         return match ($name) {
             NotBlank::class => 'not_blank: true',
-            Length::class   => $this->emitLength($args),
-            Min::class      => 'min: ' . $this->yamlScalar($args[0] ?? $args['min'] ?? 0),
-            Max::class      => 'max: ' . $this->yamlScalar($args[0] ?? $args['max'] ?? 0),
+            Length::class   => $this->emitLength($args, $propName),
+            Min::class      => 'min: ' . $this->yamlScalar($this->requireBound($args, 'min', Min::class, $propName)),
+            Max::class      => 'max: ' . $this->yamlScalar($this->requireBound($args, 'max', Max::class, $propName)),
             InSet::class    => $this->emitInSet($args),
             Url::class      => 'url: true',
             Email::class    => 'email: true',
             default         => $this->refuse($name, $propName),
         };
+    }
+
+    /**
+     * @param array<int|string, mixed> $args
+     */
+    private function requireBound(array $args, string $key, string $attr, string $propName): int|float
+    {
+        $value = $args[0] ?? $args[$key] ?? null;
+        if ($value === null) {
+            // Unreachable in practice: Min/Max attribute constructors
+            // require the bound, so PHP throws ArgumentCountError at
+            // attribute instantiation. But getArguments() peeks at
+            // syntax-tree args without instantiating, so a typo like
+            // `#[Min]` (no args) would land here as []. Make the
+            // failure explicit instead of silently emitting `min: 0`.
+            throw new \RuntimeException(
+                "PolyparityExporter: $attr on property '$propName' has no value; "
+                . "attribute requires a numeric bound."
+            );
+        }
+        return $value;
     }
 
     private function refuse(string $attrName, string $propName): ?string
@@ -163,10 +198,18 @@ final class PolyparityExporter
     /**
      * @param array<int|string, mixed> $args
      */
-    private function emitLength(array $args): string
+    private function emitLength(array $args, string $propName): ?string
     {
         $min = $args[0] ?? $args['min'] ?? null;
         $max = $args[1] ?? $args['max'] ?? null;
+        if ($min === null && $max === null) {
+            // `#[Length]` with no bounds is a Binder no-op (the
+            // validator returns null for both bound checks). Emitting
+            // `length: { }` is at best vacuous, at worst invalid for
+            // strict polyparity parsers — skip the constraint entirely
+            // to mirror the no-op behaviour.
+            return null;
+        }
         $parts = [];
         if ($min !== null) {
             $parts[] = 'min: ' . (int) $min;

--- a/src/Rxn/Framework/Tests/Codegen/Fixture/EmptyLengthDto.php
+++ b/src/Rxn/Framework/Tests/Codegen/Fixture/EmptyLengthDto.php
@@ -1,0 +1,17 @@
+<?php declare(strict_types=1);
+
+namespace Rxn\Framework\Tests\Codegen\Fixture;
+
+use Rxn\Framework\Http\Attribute\Length;
+use Rxn\Framework\Http\Binding\RequestDto;
+
+/**
+ * `#[Length]` with no bounds. Both `min` and `max` are null, so
+ * the Binder validator is a no-op. The exporter must skip emitting
+ * the constraint rather than producing `length: { }`.
+ */
+final class EmptyLengthDto implements RequestDto
+{
+    #[Length]
+    public ?string $note = null;
+}

--- a/src/Rxn/Framework/Tests/Codegen/Fixture/ImplicitRequiredDto.php
+++ b/src/Rxn/Framework/Tests/Codegen/Fixture/ImplicitRequiredDto.php
@@ -1,0 +1,19 @@
+<?php declare(strict_types=1);
+
+namespace Rxn\Framework\Tests\Codegen\Fixture;
+
+use Rxn\Framework\Http\Binding\RequestDto;
+
+/**
+ * Property is non-nullable with no default and no `#[Required]` —
+ * Binder treats this as effectively required (see the missing-field
+ * branch in Binder::bind that emits "is required" when the property
+ * has neither a default nor a nullable type).
+ *
+ * The exporter must mirror this so the polyparity spec doesn't
+ * accept inputs the PHP server rejects.
+ */
+final class ImplicitRequiredDto implements RequestDto
+{
+    public string $code;
+}

--- a/src/Rxn/Framework/Tests/Codegen/Fixture/RequiredWithDefaultDto.php
+++ b/src/Rxn/Framework/Tests/Codegen/Fixture/RequiredWithDefaultDto.php
@@ -1,0 +1,18 @@
+<?php declare(strict_types=1);
+
+namespace Rxn\Framework\Tests\Codegen\Fixture;
+
+use Rxn\Framework\Http\Attribute\Required;
+use Rxn\Framework\Http\Binding\RequestDto;
+
+/**
+ * `#[Required]` plus a default value. Binder's missing-field branch
+ * fires "is required" before reaching the default-application path,
+ * so the default is effectively dead — the exporter must not emit
+ * `default:` in this case.
+ */
+final class RequiredWithDefaultDto implements RequestDto
+{
+    #[Required]
+    public string $name = 'unused-default';
+}

--- a/src/Rxn/Framework/Tests/Codegen/Fixture/StringMinDto.php
+++ b/src/Rxn/Framework/Tests/Codegen/Fixture/StringMinDto.php
@@ -1,0 +1,20 @@
+<?php declare(strict_types=1);
+
+namespace Rxn\Framework\Tests\Codegen\Fixture;
+
+use Rxn\Framework\Http\Attribute\Min;
+use Rxn\Framework\Http\Binding\RequestDto;
+
+/**
+ * Invalid attribute usage: `#[Min]` with a string argument.
+ * Min's constructor is typed `int|float` with strict_types, so
+ * `newInstance()` throws a TypeError at runtime — Binder rejects
+ * this too. The exporter must surface the same rejection with a
+ * clear message rather than a confusing return-type TypeError.
+ */
+final class StringMinDto implements RequestDto
+{
+    /** @phpstan-ignore-next-line intentional misuse for the test */
+    #[Min('5')]
+    public int $n;
+}

--- a/src/Rxn/Framework/Tests/Codegen/PolyparityExporterTest.php
+++ b/src/Rxn/Framework/Tests/Codegen/PolyparityExporterTest.php
@@ -222,4 +222,17 @@ final class PolyparityExporterTest extends TestCase
         $yaml = (new PolyparityExporter())->emit(Fixture\EmptyLengthDto::class);
         $this->assertStringNotContainsString('length:', $yaml);
     }
+
+    public function testRejectsNonNumericMinBoundWithClearMessage(): void
+    {
+        // `#[Min('5')]` would also be rejected by Binder at
+        // newInstance() time (Min's int|float constructor under
+        // strict_types). The exporter must surface the same
+        // rejection with a clear message, not a return-type
+        // TypeError on the internal helper.
+        $exporter = new PolyparityExporter();
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessageMatches('/Min.*must be int\|float, got string/i');
+        $exporter->emit(Fixture\StringMinDto::class);
+    }
 }

--- a/src/Rxn/Framework/Tests/Codegen/PolyparityExporterTest.php
+++ b/src/Rxn/Framework/Tests/Codegen/PolyparityExporterTest.php
@@ -190,4 +190,36 @@ final class PolyparityExporterTest extends TestCase
         $this->expectExceptionMessageMatches('/must implement/i');
         $exporter->emit(\stdClass::class);
     }
+
+    public function testEmitsImplicitRequiredForNonNullableNoDefault(): void
+    {
+        // Mirror Binder: a non-nullable property with no default and
+        // no #[Required] is still effectively required (Binder emits
+        // "is required" in the missing-field branch).
+        $yaml = (new PolyparityExporter())->emit(Fixture\ImplicitRequiredDto::class);
+        $this->assertStringContainsString(
+            "    code:\n      type: string\n      required: true",
+            $yaml,
+            'non-nullable + no-default property must export as required: true',
+        );
+    }
+
+    public function testSuppressesDefaultWhenRequiredIsTrue(): void
+    {
+        // Binder ignores the default when #[Required] is set (the
+        // missing-field branch fires first with "is required"). The
+        // exported spec must not include a misleading default.
+        $yaml = (new PolyparityExporter())->emit(Fixture\RequiredWithDefaultDto::class);
+        $this->assertStringContainsString('required: true', $yaml);
+        $this->assertStringNotContainsString('default:', $yaml);
+    }
+
+    public function testSkipsLengthWithBothBoundsNull(): void
+    {
+        // `#[Length]` with no bounds is a Binder no-op. Emitting
+        // `length: { }` would be at best vacuous, at worst invalid
+        // for strict polyparity parsers.
+        $yaml = (new PolyparityExporter())->emit(Fixture\EmptyLengthDto::class);
+        $this->assertStringNotContainsString('length:', $yaml);
+    }
 }


### PR DESCRIPTION
## Summary

PR #41 (PolyparityExporter) merged with five unresolved Copilot review threads. Four were real bugs, one cosmetic. This PR addresses them.

## What's fixed

| # | Concern | Fix |
|---|---|---|
| 1 | Required not auto-emitted for non-nullable + no-default | Mirror Binder: emit \`required: true\` when the property is non-nullable, has no default, and no \`#[Required]\` |
| 2 | \`default:\` emitted alongside \`required: true\` | Suppress default when required (Binder ignores default when Required is set) |
| 3 | Explicit \`= null\` default dropped | Left as-is — functionally equivalent to no-default-nullable, both Binder branches write null. End-to-end smoke against polyparity-php confirmed |
| 4 | \`#[Min]\` / \`#[Max]\` with no args silently emit 0 | Throw \`RuntimeException\` (defensive — unreachable in practice but \`getArguments()\` peeks at syntax-tree args without instantiating) |
| 5 | \`length: { }\` for \`#[Length]\` with no bounds | Skip the constraint entirely (mirrors Binder's no-op) |

## Tests

- New fixtures: \`ImplicitRequiredDto\`, \`RequiredWithDefaultDto\`, \`EmptyLengthDto\`.
- 3 new tests covering each fixed case.
- Existing 5 snapshot tests unchanged — none of the prior fixtures exercised the affected branches, so the bridge against polyparity-php stays green.

## Test plan

- [x] \`vendor/bin/phpunit\` — 571 tests / 1176 assertions, all green
- [x] No hot-path code touched