### PR TITLE
docs: reflect OpenAPI snapshot contract gate

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,18 +106,23 @@ Opinionated pieces worth naming:
 - **Typed route constraints** (`{id:int}`, `{slug:slug}`,
   `{id:uuid}`, custom) so `/users/foo` falls through to 404
   instead of reaching a controller that has to validate and throw.
-- **Reflection-driven OpenAPI** — the framework knows your
-  controllers; why duplicate that in a YAML file? DTO validation
-  attributes map one-to-one to JSON Schema keywords, so the spec
-  *can't* drift from the runtime behaviour — both sides read the
-  same class.
+- **Reflection-driven OpenAPI + snapshot contract gate** — the
+  framework knows your controllers; why duplicate that in a YAML
+  file? DTO validation attributes map one-to-one to JSON Schema
+  keywords, so the spec *can't* drift from the runtime behaviour
+  — both sides read the same class. `bin/rxn openapi:check`
+  closes the loop in CI: regenerate spec → diff against the
+  committed snapshot → fail the build on breaking changes
+  (operation removed, type changed, constraint tightened, …)
+  unless the PR opts in. Schema-as-truth becomes
+  schema-as-governance.
 - **Production-safe by default** — stack traces never ship outside
   dev, boundary input sanitisation is one env flag, session
   cookies auto-flip to `Secure` behind an HTTPS proxy.
 
 ### Simplicity
 
-Small enough to read end to end — **~12K LOC of framework code
+Small enough to read end to end — **~13K LOC of framework code
 ships what a comparably-featured Slim or Mezzio composition
 reaches in 70–100K LOC of vendor packages** (DTO binding +
 attribute-driven validation, OpenAPI from reflection, idempotency
@@ -212,7 +217,7 @@ cumulative scoreboard is in
 
 ```bash
 composer install
-vendor/bin/phpunit          # 560 tests, 1159 assertions
+vendor/bin/phpunit          # 626 tests, 1310 assertions
 bin/rxn help                # CLI subcommands
 ```
 
@@ -293,7 +298,7 @@ end-to-end HTTP smoke job against MySQL 8
 
 Test counts:
 
-- **Rxn framework:** 560 tests / 1159 assertions (`vendor/bin/phpunit`).
+- **Rxn framework:** 626 tests / 1310 assertions (`vendor/bin/phpunit`).
 - **[`davidwyly/rxn-orm`](https://github.com/davidwyly/rxn-orm)**
   (query builder): 68 tests / 132 assertions, run in that repo.
 
@@ -440,6 +445,24 @@ methodology is in
          `#[Pattern]` → `pattern`, `#[InSet]` → `enum`) — the same
          class drives both validation and the spec, so they can't
          drift
+   - [X] Snapshot-tested contract gate (`bin/rxn openapi:check`;
+         `Codegen\Snapshot\OpenApiSnapshot`) — diffs the generated
+         spec against a committed `openapi.snapshot.json` and
+         classifies drift as breaking (operation/parameter/property
+         removals, type changes, tightened constraints, required-
+         toggles) or additive (new operations, new optional fields,
+         loosened constraints). Three exit codes for CI gating:
+         0 clean, 1 additive only or `--allow-breaking` override,
+         2 breaking detected
+   - [X] Cross-language validator twin (`Codegen\JsValidatorEmitter`)
+         — emits a vanilla ES module that agrees with `Binder::bind`
+         on 0 disagreements / 10K random inputs across four fixture
+         DTOs per CI run
+   - [X] [Polyparity](https://github.com/davidwyly/polyparity)
+         YAML exporter (`Codegen\PolyparityExporter`) — same DTO
+         drives Rxn's PHP server, the JS twin, AND a polyparity
+         spec consumable by polyparity's TS / Python / future-
+         language siblings
 - [X] In-process HTTP test client + fluent response assertions
       (`Testing\TestClient` + `TestResponse`) — no web server, no
       curl, PHPUnit-integrated failures

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -151,6 +151,8 @@ Flags:
 | `--snapshot=<PATH>` | Snapshot file path. Default: `openapi.snapshot.json` in the project root. |
 | `--update` | Overwrite the snapshot with the current spec; exits 0. |
 | `--allow-breaking` | Downgrade exit `2` to exit `1` (the diff still prints). For PRs explicitly authorised to break the contract — e.g. behind a `breaking-change` review label. |
+| `--title=<T>` | `info.title` for the regenerated spec. Default: `Rxn API`. Match this to the value used in your `bin/rxn openapi --update` flow so the snapshot doesn't drift on metadata. |
+| `--version=<V>` | `info.version` for the regenerated spec. Default: `0.1.0`. Same matching caveat as `--title`. |
 | `--ns=<NS>` | App PSR-4 prefix. Defaults to `APP_NAMESPACE`. |
 | `--root=<DIR>` | Alternative project root to scan. |
 
@@ -165,14 +167,20 @@ Classification rules (mirrors `Codegen\Snapshot\OpenApiSnapshot::diff`):
   snapshot doesn't track request- vs response-side ref usage);
   new required → BREAKING; new optional → ADDITIVE; type changed
   → BREAKING; became required → BREAKING.
-- **Constraints** (`minimum`, `maximum`, `minLength`,
-  `maxLength`, `enum`, `pattern`, `format`, `nullable`,
-  `default`): tightening → BREAKING; loosening → ADDITIVE;
-  `default` changes → ADDITIVE either way.
-- **Conservative on ambiguity**: when the rule can't disambiguate
-  (e.g. nullable flips, regex pattern changes), flag BREAKING so
-  the gate fails loudly rather than silently passing real
-  regressions.
+- **Numeric / set constraints** (`minimum`, `maximum`,
+  `minLength`, `maxLength`, `enum`): tightening → BREAKING;
+  loosening → ADDITIVE.
+- **Opaque scalars** (`pattern`, `format`): first-time appearance
+  or any change → BREAKING (regex/format identity is hard to
+  reason about); removal → ADDITIVE.
+- **`nullable`**: any flip → BREAKING in either direction. The
+  snapshot doesn't know whether a referenced schema is reached
+  via a request body or a response, and one of those breaks in
+  each direction (request: nullable→non-nullable rejects nulls
+  the client used to send; response: non-nullable→nullable lets
+  through nulls the client may not handle). Conservative.
+- **`default`**: ADDITIVE either way (defaults document intent;
+  the wire contract isn't bound by them).
 
 Pairs naturally with `JsValidatorEmitter` (PHP↔JS validator
 parity) and `PolyparityExporter` (cross-language YAML spec):

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -108,6 +108,77 @@ Pipe the output into Swagger UI, Redocly, or any OpenAPI
 consumer — or pair with `Http\OpenApi\SwaggerUi::html($specUrl)`
 for one-line interactive docs.
 
+## `bin/rxn openapi:check`
+
+CI gate that catches schema drift on PR open. Regenerates the
+OpenAPI spec the same way `bin/rxn openapi` does, then diffs it
+against `openapi.snapshot.json` (or whatever path
+`--snapshot=PATH` names) committed in the repo. Exits with one
+of three codes so CI policy can decide what to do:
+
+| Exit | Meaning |
+|---|---|
+| `0` | No drift. |
+| `1` | Additive changes only (new operations, new optional fields, loosened constraints). Or breaking changes when `--allow-breaking` is passed. |
+| `2` | Breaking changes detected and not opted-in. |
+
+Seed the snapshot with `--update`:
+
+```
+$ bin/rxn openapi:check --update
+Updated snapshot at /path/to/repo/openapi.snapshot.json
+```
+
+Then commit the file. On the next PR that changes a DTO, the
+gate runs:
+
+```
+$ bin/rxn openapi:check
+Breaking changes (2):
+  [breaking] components.schemas.CreateProduct.properties.price — maximum tightened from 1000000 to 100000
+  [breaking] paths./v1.1/products/show.parameters.query.id — parameter became required
+Additive changes (1):
+  [additive] components.schemas.Product.properties.thumbnail_url — optional property added
+
+If the changes are intentional, refresh the snapshot:
+  bin/rxn openapi:check --update
+```
+
+Flags:
+
+| Flag | Purpose |
+|---|---|
+| `--snapshot=<PATH>` | Snapshot file path. Default: `openapi.snapshot.json` in the project root. |
+| `--update` | Overwrite the snapshot with the current spec; exits 0. |
+| `--allow-breaking` | Downgrade exit `2` to exit `1` (the diff still prints). For PRs explicitly authorised to break the contract — e.g. behind a `breaking-change` review label. |
+| `--ns=<NS>` | App PSR-4 prefix. Defaults to `APP_NAMESPACE`. |
+| `--root=<DIR>` | Alternative project root to scan. |
+
+Classification rules (mirrors `Codegen\Snapshot\OpenApiSnapshot::diff`):
+
+- **Operations / paths**: removed → BREAKING, added → ADDITIVE.
+- **Parameters** (keyed by `(name, in)` — query `id` and header
+  `id` are different parameters): removed or made required →
+  BREAKING; new required → BREAKING; new optional → ADDITIVE;
+  type changed → BREAKING.
+- **Schema properties**: removed → BREAKING (conservative — the
+  snapshot doesn't track request- vs response-side ref usage);
+  new required → BREAKING; new optional → ADDITIVE; type changed
+  → BREAKING; became required → BREAKING.
+- **Constraints** (`minimum`, `maximum`, `minLength`,
+  `maxLength`, `enum`, `pattern`, `format`, `nullable`,
+  `default`): tightening → BREAKING; loosening → ADDITIVE;
+  `default` changes → ADDITIVE either way.
+- **Conservative on ambiguity**: when the rule can't disambiguate
+  (e.g. nullable flips, regex pattern changes), flag BREAKING so
+  the gate fails loudly rather than silently passing real
+  regressions.
+
+Pairs naturally with `JsValidatorEmitter` (PHP↔JS validator
+parity) and `PolyparityExporter` (cross-language YAML spec):
+three downstream artifacts from one `RequestDto` source of
+truth, three drift-detection mechanisms in one repo.
+
 ## Environment knobs
 
 | Variable | Purpose |

--- a/docs/design-philosophy.md
+++ b/docs/design-philosophy.md
@@ -44,7 +44,7 @@ final class CreateProduct implements RequestDto {
 }
 ```
 
-This one declaration drives *four* consumers:
+This one declaration drives *seven* consumers:
 
 1. **Binder** — hydrates `$dto = Binder::bind(CreateProduct::class)`
    from the request bag, casting strings to typed properties.
@@ -55,10 +55,25 @@ This one declaration drives *four* consumers:
 4. **Compiled fast path** — `Binder::compileFor($class)` reads the
    same reflection and emits straight-line PHP with the per-property
    work inlined (6.4× speedup on this DTO shape).
+5. **JS validator twin** — `Codegen\JsValidatorEmitter` emits a
+   vanilla ES module that agrees with `Binder::bind` on 0
+   disagreements / 10K random inputs across four fixture DTOs per
+   CI run. PHP shops with a TS / vanilla-JS frontend get
+   drift-free validation across the wire.
+6. **Polyparity YAML spec** — `Codegen\PolyparityExporter` emits a
+   [polyparity](https://github.com/davidwyly/polyparity) spec
+   that polyparity's TS / Python / future-language siblings
+   consume. Same coverage matrix as the JS emitter.
+7. **OpenAPI snapshot contract** — `Codegen\Snapshot\OpenApiSnapshot`
+   serialises the generated spec to a stable byte sequence and
+   classifies drift between two snapshots as breaking vs
+   additive. `bin/rxn openapi:check` closes the loop in CI:
+   regenerate → diff against the committed snapshot → fail the
+   build on contract breaks unless the PR opts in.
 
 In Slim / Laravel / Symfony those are typically three or four
 separate libraries with three or four config formats. Adding a
-property in Rxn automatically updates all four consumers, because
+property in Rxn automatically updates all seven consumers, because
 they all start from the same PHP class.
 
 This is the structural reason `Binder::compileFor` exists at all
@@ -225,7 +240,7 @@ to read is slow to *develop in*. Time-to-first-bug-fixed is a
 real metric.
 
 Rxn fits in your head:
-- The framework is ~12k LOC of PHP excluding tests; the dispatch
+- The framework is ~13k LOC of PHP excluding tests; the dispatch
   spine — Container, Router, Pipeline, Binder, Validator,
   Request, Response — is ~3k of that, readable in one sitting.
   Middlewares, OpenAPI, scaffolding, and the legacy ActiveRecord
@@ -350,13 +365,13 @@ principles are how we keep the substrate healthy.
 | Principle | Concrete example |
 |---|---|
 | 1 — opinionated narrowing | `Response::__construct` produces JSON; `App::run` rolls every uncaught exception into RFC 7807; no Accept header branch anywhere |
-| 2 — schema as truth | `Binding\RequestDto` + `#[Required]` etc. → consumed by `Binder`, `Validator`, `OpenApi\Generator`, `Binder::compileFor` |
+| 2 — schema as truth | `Binding\RequestDto` + `#[Required]` etc. → consumed by `Binder`, `Validator`, `OpenApi\Generator`, `Binder::compileFor`, `Codegen\JsValidatorEmitter`, `Codegen\PolyparityExporter`, `Codegen\Snapshot\OpenApiSnapshot` (gate) |
 | 3 — same code, two profiles | `Validator::check` / `Validator::compile`; `Binder::bind` / `Binder::compileFor`; `Container::get` (transparent) |
 | 4 — schema-compile PHP, not C | `bench/ab/experiments/2026-04-29-compiled-json-encoder.md` — negative result that produced the rule |
 | 5 — convention + escape hatch | `App::run` convention router → `Http\Router` explicit; `Container` autowire → `bind()` |
 | 6 — measure to commit | `bench/ab.php` driver, 16 experiment writeups, 4 negative-result branches preserved on origin |
 | 7 — transparent vs visible opt-in | Container's 5 stacked caches: zero API change. `Validator::compile`: visible because of the FPM tradeoff |
-| 8 — smallness as constraint | ~12k LOC framework, ~3k LOC dispatch spine (Container, Router, Pipeline, Binder, Validator, Request, Response) — readable in one sitting; the rest is opt-in subsystems |
+| 8 — smallness as constraint | ~13k LOC framework, ~3k LOC dispatch spine (Container, Router, Pipeline, Binder, Validator, Request, Response) — readable in one sitting; the rest is opt-in subsystems |
 | 9 — ergonomics are performance | `bin/preload.php`, `bench/ab/CONSOLIDATION.md`, `docs/index.md`'s topic table |
 | 10 — honesty | "alpha" status in README, `App::run` open-bugs note in `docs/benchmarks.md`, the long-lived-worker caveat in every compile-path docstring |
 | 11 — optional deps via lazy autoload | `Psr16IdempotencyStore` (typehints `\Psr\SimpleCache\CacheInterface`) and `Database::run()` / `ActiveRecord` (typehint `\Rxn\Orm\Builder\Buildable` / `Query`); both packages live in `composer.json`'s `suggest` block, framework loads cleanly without them |


### PR DESCRIPTION
## Summary

Doc-only followup to PR #55 (the snapshot contract gate). The framework code shipped; the doc surface was inconsistent — three user-facing pages still describe the schema-as-truth story as four consumers and the OpenAPI feature set without the gate. This PR updates them.

- **README.md** — test counts (560/1159 → 626/1310), LOC estimate (~12K → ~13K), Novelty bullet for OpenAPI now mentions the snapshot gate, OpenAPI feature checklist gets three new sub-bullets (snapshot gate, JS validator twin, polyparity YAML exporter — latter two were shipped earlier but missing from the README's feature catalogue).
- **docs/cli.md** — full \`bin/rxn openapi:check\` section: example output, exit-code table, flag table, classification rules summary, three-artifact codegen story.
- **docs/design-philosophy.md** — schema-as-truth section bumped from four consumers to seven (named: \`JsValidatorEmitter\`, \`PolyparityExporter\`, \`OpenApiSnapshot\`). The where-each-principle-shows-up table updated with the same names. ~12k → ~13k LOC.

No code changes; no behavioural change.

## Test plan

- [x] Full suite still green: 626 / 1310, no regression.
- [x] Reviewed each doc change in context to ensure links + cross-references stay coherent.