### PR TITLE
Fix migrate:status when migrations table is absent

### DIFF
--- a/src/Rxn/Framework/Data/Migration.php
+++ b/src/Rxn/Framework/Data/Migration.php
@@ -3,6 +3,7 @@
 namespace Rxn\Framework\Data;
 
 use Rxn\Framework\Error\DatabaseException;
+use Rxn\Framework\Error\QueryException;
 
 /**
  * Minimal, file-based schema migration runner.
@@ -67,13 +68,23 @@ class Migration
     {
         try {
             $rows = $this->database->fetchAll("SELECT filename FROM `" . self::TABLE . "` ORDER BY filename ASC");
-        } catch (\PDOException $exception) {
-            if ((int)$exception->getCode() === 1146) {
+        } catch (\PDOException | QueryException $exception) {
+            if ($this->isMissingMigrationsTable($exception)) {
                 return [];
             }
             throw $exception;
         }
         return array_column($rows ?: [], 'filename');
+    }
+
+    private function isMissingMigrationsTable(\Throwable $exception): bool
+    {
+        $message = $exception->getMessage();
+        $code    = (string)$exception->getCode();
+
+        return strpos($code, '42S02') !== false
+            || strpos($message, '1146') !== false
+            || stripos($message, 'no such table') !== false;
     }
 
     /**


### PR DESCRIPTION
### Motivation
- `migrate:status` now constructs `Migration` with `ensureTable=false`, so the `rxn_migrations` table may not exist on fresh schemas and must be handled gracefully.
- The framework `Query` layer wraps PDO errors in `QueryException`, so `Migration::applied()` catching only `\PDOException` could miss the real exception and crash instead of returning an empty applied list.
- The change restores the previous behavior of showing pending migrations on a fresh database by recognizing missing-table errors regardless of the exception wrapper.

### Description
- Import `QueryException` in `src/Rxn/Framework/Data/Migration.php` and extend the catch in `applied()` to `\PDOException | QueryException` so both error types are handled.
- Add a private helper `isMissingMigrationsTable()` that detects missing-table conditions by checking the SQLSTATE `42S02`, MySQL driver message text `1146`, or SQLite-style `no such table` in the exception `message` or `code`.
- Return an empty applied list when the helper detects a missing migrations table and rethrow the exception for all other failures, preserving existing behavior for non-missing-table errors.

### Testing
- Ran a PHP syntax check with `php -l src/Rxn/Framework/Data/Migration.php`, which succeeded (no syntax errors).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f69568e3f0832fb022f87a94a1a080)