### PR TITLE
feat(Observability): framework event surface for theme 2.x listeners

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -89,9 +89,10 @@ Events::useDispatcher($dispatcher);
 
 #### Tests
 
-- 6 unit tests for `Events` (no-op without dispatcher, dispatch
+- 8 unit tests for `Events` (no-op without dispatcher, dispatch
   through, accessor, pair-id format, stoppable semantics, custom
-  dispatcher implementation).
+  dispatcher implementation, `enabled()` gate, `currentPairId()`
+  round-trip).
 - 5 Pipeline integration tests (one pair per middleware, ordered,
   pair-id consistency, exit-on-throw, FQCN populated, no-op
   without dispatcher).
@@ -99,8 +100,11 @@ Events::useDispatcher($dispatcher);
   method-mismatch).
 - 4 Binder integration tests (runtime path, compiled path,
   failure grouping by field, compiled path emits on failure too).
+- 5 App::serve integration tests (full success path event tree,
+  404 miss path, 405 method-mismatch path, pair-id slot
+  cleared in finally, no-op without dispatcher).
 
-Suite 712 → 731 / 1569.
+Suite 712 → 738 / 1596.
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,11 +79,19 @@ Events::useDispatcher($dispatcher);
 
 #### What it costs
 
-- **Per emit when no dispatcher installed:** one null check
-  (~5 ns). Events are constructed regardless — the cost is the
-  value-object allocation, not the dispatch.
-- **Per emit with a no-op listener:** one method call + iterator
-  walk (~50 ns). Negligible against a request's overall cost.
+- **Per emit point when no dispatcher installed:** one
+  `Events::enabled()` bool read. The event object is NOT
+  constructed and `random_bytes(8)` (for pair-id minting) is
+  NOT called — the call site short-circuits before either.
+  Apps that don't subscribe pay roughly nothing per request
+  hop.
+- **Per emit with a no-op listener:** event-object allocation
+  (a few field copies) + one method call + iterator walk
+  (~50 ns total). Negligible against a request's overall cost.
+- **Hottest path preservation:** `Binder::bind()`'s compiled
+  fast path returns the closure invocation directly when
+  observability is disabled — no `try/catch` frame, no
+  intermediate `$dto` assignment.
 - **No new dependencies.** Leans on the existing PSR-14 wiring
   (`Rxn\Framework\Event\EventDispatcher` + `ListenerProvider`).
 
@@ -100,11 +108,12 @@ Events::useDispatcher($dispatcher);
   method-mismatch).
 - 4 Binder integration tests (runtime path, compiled path,
   failure grouping by field, compiled path emits on failure too).
-- 5 App::serve integration tests (full success path event tree,
+- 6 App::serve integration tests (full success path event tree,
   404 miss path, 405 method-mismatch path, pair-id slot
-  cleared in finally, no-op without dispatcher).
+  cleared in finally, no-op without dispatcher, invokable
+  handler label).
 
-Suite 712 → 738 / 1596.
+Suite 712 → 739 / 1598.
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,98 @@ read alongside the wins.
 
 ## Unreleased
 
+### Observability event surface (`feat/otel-spans-via-psr14`)
+
+Eight first-party events emitted from the framework's request
+lifecycle, dispatched through PSR-14. Apps subscribe a single
+listener on the `FrameworkEvent` marker interface and receive
+the lot — request bookends, per-middleware brackets, route-match
+metadata, binder invocation + validation outcome, handler
+brackets — without bolting on per-component instrumentation.
+
+This is the foundation for [horizons.md theme 2.1](docs/horizons.md)
+(OpenTelemetry spans) and theme 2.2 (Prometheus metrics). Both
+are listeners over the same event channel; this PR ships the
+substrate. The events themselves carry no OTel / Prometheus
+dependency — they're plain value objects, so apps that don't
+subscribe pay zero runtime cost beyond a static-slot null check
+per emit.
+
+#### Added
+
+- **`Rxn\Framework\Observability\Events`** static helper:
+  `useDispatcher()` installs a PSR-14 dispatcher (no-op until
+  installed); `emit()` is the per-call-site dispatch helper that
+  short-circuits when no dispatcher is set; `newPairId()` mints
+  a 64-bit hex id for bracketing entered/exited boundaries.
+- **`Rxn\Framework\Observability\Event\FrameworkEvent`** marker
+  interface — listeners that want every event subscribe once on
+  this. The PSR-14 ListenerProvider walks implemented interfaces
+  during dispatch, so a single registration covers every concrete
+  event type.
+- **Eight concrete events** (all under `Observability\Event\*`):
+  `RequestReceived` / `ResponseEmitted` (request bookends, paired
+  by id), `MiddlewareEntered` / `MiddlewareExited` (one pair per
+  middleware in the stack, with `$index` and `$throwable` on
+  failure), `RouteMatched` (template + extracted params on a
+  successful match), `BinderInvoked` (with `path` tag —
+  `compiled` or `runtime` — for compile-cache hit-ratio
+  metrics), `ValidationCompleted` (failures grouped by field
+  name; fires on success and failure, both runtime and compiled
+  paths), `HandlerInvoked` (entered/exited with throwable on
+  handler failure).
+- **Dispatch wiring** in `Pipeline::handle` (per-middleware
+  bracket, exit-on-throw), `Router::match` (both static fast
+  lane and regex bucket), `Binder::bind` (both runtime walker
+  and compiled path), `App::serve` (request + handler
+  bookends).
+
+#### How apps wire it
+
+```php
+$provider   = new ListenerProvider();
+$dispatcher = new EventDispatcher($provider);
+
+// Register one listener for every framework event:
+$provider->listen(FrameworkEvent::class, $myListener);
+
+// Or target a specific event:
+$provider->listen(ValidationCompleted::class, function (ValidationCompleted $e): void {
+    if ($e->isFailure()) {
+        $myMetrics->increment('validation_failures', $e->failures);
+    }
+});
+
+Events::useDispatcher($dispatcher);
+```
+
+#### What it costs
+
+- **Per emit when no dispatcher installed:** one null check
+  (~5 ns). Events are constructed regardless — the cost is the
+  value-object allocation, not the dispatch.
+- **Per emit with a no-op listener:** one method call + iterator
+  walk (~50 ns). Negligible against a request's overall cost.
+- **No new dependencies.** Leans on the existing PSR-14 wiring
+  (`Rxn\Framework\Event\EventDispatcher` + `ListenerProvider`).
+
+#### Tests
+
+- 6 unit tests for `Events` (no-op without dispatcher, dispatch
+  through, accessor, pair-id format, stoppable semantics, custom
+  dispatcher implementation).
+- 5 Pipeline integration tests (one pair per middleware, ordered,
+  pair-id consistency, exit-on-throw, FQCN populated, no-op
+  without dispatcher).
+- 4 Router integration tests (static path, dynamic params, miss,
+  method-mismatch).
+- 4 Binder integration tests (runtime path, compiled path,
+  failure grouping by field, compiled path emits on failure too).
+
+Suite 712 → 731 / 1569.
+
+---
+
 ### Profile-guided compilation (`feat/profile-guided-compilation`)
 
 Track which DTOs are actually hot at runtime; compile only

--- a/README.md
+++ b/README.md
@@ -223,7 +223,7 @@ cumulative scoreboard is in
 
 ```bash
 composer install
-vendor/bin/phpunit          # 731 tests, 1569 assertions
+vendor/bin/phpunit          # 738 tests, 1596 assertions
 bin/rxn help                # CLI subcommands
 ```
 
@@ -304,7 +304,7 @@ end-to-end HTTP smoke job against MySQL 8
 
 Test counts:
 
-- **Rxn framework:** 731 tests / 1569 assertions (`vendor/bin/phpunit`).
+- **Rxn framework:** 738 tests / 1596 assertions (`vendor/bin/phpunit`).
 - **[`davidwyly/rxn-orm`](https://github.com/davidwyly/rxn-orm)**
   (query builder): 68 tests / 132 assertions, run in that repo.
 

--- a/README.md
+++ b/README.md
@@ -223,7 +223,7 @@ cumulative scoreboard is in
 
 ```bash
 composer install
-vendor/bin/phpunit          # 708 tests, 1504 assertions
+vendor/bin/phpunit          # 731 tests, 1569 assertions
 bin/rxn help                # CLI subcommands
 ```
 
@@ -304,7 +304,7 @@ end-to-end HTTP smoke job against MySQL 8
 
 Test counts:
 
-- **Rxn framework:** 708 tests / 1504 assertions (`vendor/bin/phpunit`).
+- **Rxn framework:** 731 tests / 1569 assertions (`vendor/bin/phpunit`).
 - **[`davidwyly/rxn-orm`](https://github.com/davidwyly/rxn-orm)**
   (query builder): 68 tests / 132 assertions, run in that repo.
 

--- a/README.md
+++ b/README.md
@@ -223,7 +223,7 @@ cumulative scoreboard is in
 
 ```bash
 composer install
-vendor/bin/phpunit          # 738 tests, 1596 assertions
+vendor/bin/phpunit          # 739 tests, 1598 assertions
 bin/rxn help                # CLI subcommands
 ```
 
@@ -304,7 +304,7 @@ end-to-end HTTP smoke job against MySQL 8
 
 Test counts:
 
-- **Rxn framework:** 738 tests / 1596 assertions (`vendor/bin/phpunit`).
+- **Rxn framework:** 739 tests / 1598 assertions (`vendor/bin/phpunit`).
 - **[`davidwyly/rxn-orm`](https://github.com/davidwyly/rxn-orm)**
   (query builder): 68 tests / 132 assertions, run in that repo.
 

--- a/docs/horizons.md
+++ b/docs/horizons.md
@@ -216,6 +216,31 @@ The framework already has PSR-14 wired ([`Rxn\Framework\Event\EventDispatcher`](
 Most frameworks make you bolt on OpenTelemetry + Prometheus +
 structured logging from three different libraries.
 
+### 2.0 Observability event surface — REALIZED
+
+See `Rxn\Framework\Observability\Events` (static dispatch slot)
+and `Rxn\Framework\Observability\Event\*` — eight first-party
+events: `RequestReceived` / `ResponseEmitted` (paired by id),
+`MiddlewareEntered` / `MiddlewareExited` (per-middleware brackets,
+exit fires even on throw), `RouteMatched` (template + params),
+`BinderInvoked` (with `path` tag for compile-cache hit ratio),
+`ValidationCompleted` (failures grouped by field name),
+`HandlerInvoked` (entered/exited brackets). Apps subscribe a
+single listener on the `FrameworkEvent` marker interface and
+receive the lot.
+
+**Cost reality:** ~250 LOC of framework code + 19 tests. No new
+dependencies — leans on the existing PSR-14 dispatcher /
+provider. Per-emit cost without a dispatcher installed is one
+null check (~5 ns); with a no-op listener, ~50 ns.
+
+**Status:** Shipped as the substrate for 2.1 (OTel) and 2.2
+(Prometheus). Both are listeners over the same channel; this
+layer makes them thin shims rather than full instrumentation
+projects.
+
+---
+
 ### 2.1 OpenTelemetry spans via PSR-14
 
 **Claim:** Every middleware, route, binder, validator emits an

--- a/docs/horizons.md
+++ b/docs/horizons.md
@@ -229,10 +229,12 @@ exit fires even on throw), `RouteMatched` (template + params),
 single listener on the `FrameworkEvent` marker interface and
 receive the lot.
 
-**Cost reality:** ~250 LOC of framework code + 19 tests. No new
-dependencies — leans on the existing PSR-14 dispatcher /
-provider. Per-emit cost without a dispatcher installed is one
-null check (~5 ns); with a no-op listener, ~50 ns.
+**Cost reality:** ~250 LOC of framework code + 27 tests
+(8 Events helper + 5 Pipeline + 4 Router + 4 Binder + 6
+App::serve). No new dependencies — leans on the existing
+PSR-14 dispatcher / provider. Per-emit cost without a
+dispatcher installed is one bool read (`Events::enabled()`);
+with a no-op listener, ~50 ns.
 
 **Status:** Shipped as the substrate for 2.1 (OTel) and 2.2
 (Prometheus). Both are listeners over the same channel; this

--- a/src/Rxn/Framework/App.php
+++ b/src/Rxn/Framework/App.php
@@ -239,10 +239,18 @@ class App
     }
 
     /**
-     * Stringify a route handler for use as a span name. Closures
-     * become `"Closure"`; `[$obj, 'method']` becomes
-     * `"Class::method"`; `'Class::method'` strings pass through;
-     * anything else falls back to the gettype-style label.
+     * Stringify a route handler for use as a span name. Mapping:
+     *
+     *   - `\Closure`                       → `"Closure"`
+     *   - `[$obj|$cls, 'method']`          → `"Class::method"`
+     *   - non-empty string handler         → passed through verbatim
+     *     (typically `"Class::method"` already)
+     *   - invokable object (`__invoke`)    → `"Class::__invoke"`
+     *   - any other object                 → bare class name
+     *   - everything else                  → the literal `"callable"`
+     *     (the caller has stuffed something exotic, but the slot
+     *     is non-null — there's nothing more useful to say without
+     *     guessing)
      */
     private static function describeHandler(mixed $handler): string
     {

--- a/src/Rxn/Framework/App.php
+++ b/src/Rxn/Framework/App.php
@@ -121,10 +121,19 @@ class App
         $method  = $request->getMethod();
         $path    = $request->getUri()->getPath();
 
+        $pairId = \Rxn\Framework\Observability\Events::newPairId();
+        \Rxn\Framework\Observability\Events::emit(
+            new \Rxn\Framework\Observability\Event\RequestReceived($pairId, $request)
+        );
+
         $hit = $router->match($method, $path);
         if ($hit === null) {
-            $status = $router->hasMethodMismatch($method, $path) ? 405 : 404;
-            \Rxn\Framework\Http\PsrAdapter::emit(self::psrProblem($status));
+            $status   = $router->hasMethodMismatch($method, $path) ? 405 : 404;
+            $response = self::psrProblem($status);
+            \Rxn\Framework\Http\PsrAdapter::emit($response);
+            \Rxn\Framework\Observability\Events::emit(
+                new \Rxn\Framework\Observability\Event\ResponseEmitted($pairId, $response, null)
+            );
             return;
         }
 
@@ -135,7 +144,42 @@ class App
 
         $invoker ??= self::defaultHandlerInvoker(...);
 
-        $terminal = new class($hit, $invoker) implements \Psr\Http\Server\RequestHandlerInterface {
+        // Wrap the user invoker with HandlerInvoked entered/exited
+        // events. Same `$pairId` brackets the boundary; failures
+        // propagate so the pipeline sees the original exception.
+        $observingInvoker = static function (array $hit, \Psr\Http\Message\ServerRequestInterface $req) use ($invoker, $pairId): \Psr\Http\Message\ResponseInterface {
+            $handlerLabel = self::describeHandler($hit['handler'] ?? null);
+            \Rxn\Framework\Observability\Events::emit(
+                new \Rxn\Framework\Observability\Event\HandlerInvoked(
+                    $pairId,
+                    \Rxn\Framework\Observability\Event\HandlerInvoked::STATE_ENTERED,
+                    $handlerLabel,
+                )
+            );
+            try {
+                $response = $invoker($hit, $req);
+                \Rxn\Framework\Observability\Events::emit(
+                    new \Rxn\Framework\Observability\Event\HandlerInvoked(
+                        $pairId,
+                        \Rxn\Framework\Observability\Event\HandlerInvoked::STATE_EXITED,
+                        $handlerLabel,
+                    )
+                );
+                return $response;
+            } catch (\Throwable $e) {
+                \Rxn\Framework\Observability\Events::emit(
+                    new \Rxn\Framework\Observability\Event\HandlerInvoked(
+                        $pairId,
+                        \Rxn\Framework\Observability\Event\HandlerInvoked::STATE_EXITED,
+                        $handlerLabel,
+                        $e,
+                    )
+                );
+                throw $e;
+            }
+        };
+
+        $terminal = new class($hit, $observingInvoker) implements \Psr\Http\Server\RequestHandlerInterface {
             /** @param callable(array, \Psr\Http\Message\ServerRequestInterface): \Psr\Http\Message\ResponseInterface $invoker */
             public function __construct(private array $hit, private $invoker) {}
 
@@ -145,7 +189,37 @@ class App
             }
         };
 
-        \Rxn\Framework\Http\PsrAdapter::emit($pipeline->run($request, $terminal));
+        $response = $pipeline->run($request, $terminal);
+
+        \Rxn\Framework\Http\PsrAdapter::emit($response);
+        \Rxn\Framework\Observability\Events::emit(
+            new \Rxn\Framework\Observability\Event\ResponseEmitted($pairId, $response)
+        );
+    }
+
+    /**
+     * Stringify a route handler for use as a span name. Closures
+     * become `"Closure"`; `[$obj, 'method']` becomes
+     * `"Class::method"`; `'Class::method'` strings pass through;
+     * anything else falls back to the gettype-style label.
+     */
+    private static function describeHandler(mixed $handler): string
+    {
+        if ($handler instanceof \Closure) {
+            return 'Closure';
+        }
+        if (is_array($handler) && count($handler) === 2) {
+            $obj = $handler[0];
+            $cls = is_object($obj) ? $obj::class : (is_string($obj) ? $obj : 'callable');
+            return $cls . '::' . (string) $handler[1];
+        }
+        if (is_string($handler) && $handler !== '') {
+            return $handler;
+        }
+        if (is_object($handler)) {
+            return $handler::class;
+        }
+        return 'callable';
     }
 
     /**

--- a/src/Rxn/Framework/App.php
+++ b/src/Rxn/Framework/App.php
@@ -121,33 +121,91 @@ class App
         $method  = $request->getMethod();
         $path    = $request->getUri()->getPath();
 
-        $pairId = \Rxn\Framework\Observability\Events::newPairId();
-        \Rxn\Framework\Observability\Events::emit(
-            new \Rxn\Framework\Observability\Event\RequestReceived($pairId, $request)
-        );
+        // Gate every observability cost on a dispatcher actually
+        // being installed: pair-id minting (random_bytes), event
+        // construction, and dispatch all skip when nobody is
+        // listening. Apps that don't subscribe pay one method call
+        // per emit point — no allocations, no CSPRNG draws.
+        $eventsEnabled = \Rxn\Framework\Observability\Events::enabled();
+        $pairId        = $eventsEnabled
+            ? \Rxn\Framework\Observability\Events::newPairId()
+            : null;
 
-        $hit = $router->match($method, $path);
-        if ($hit === null) {
-            $status   = $router->hasMethodMismatch($method, $path) ? 405 : 404;
-            $response = self::psrProblem($status);
+        try {
+            if ($eventsEnabled && $pairId !== null) {
+                \Rxn\Framework\Observability\Events::useCurrentPairId($pairId);
+                \Rxn\Framework\Observability\Events::emit(
+                    new \Rxn\Framework\Observability\Event\RequestReceived($pairId, $request)
+                );
+            }
+
+            $hit = $router->match($method, $path);
+            if ($hit === null) {
+                $status   = $router->hasMethodMismatch($method, $path) ? 405 : 404;
+                $response = self::psrProblem($status);
+                \Rxn\Framework\Http\PsrAdapter::emit($response);
+                if ($eventsEnabled && $pairId !== null) {
+                    \Rxn\Framework\Observability\Events::emit(
+                        new \Rxn\Framework\Observability\Event\ResponseEmitted($pairId, $response)
+                    );
+                }
+                return;
+            }
+
+            $pipeline = new \Rxn\Framework\Http\Pipeline();
+            foreach ($hit['middlewares'] as $mw) {
+                $pipeline->add($mw);
+            }
+
+            $invoker ??= self::defaultHandlerInvoker(...);
+
+            // Wrap the user invoker with HandlerInvoked entered/exited
+            // events when observability is enabled; otherwise the
+            // bare invoker runs untouched.
+            $finalInvoker = ($eventsEnabled && $pairId !== null)
+                ? self::wrapInvokerWithHandlerEvents($invoker, $pairId)
+                : $invoker;
+
+            $terminal = new class($hit, $finalInvoker) implements \Psr\Http\Server\RequestHandlerInterface {
+                /** @param callable(array, \Psr\Http\Message\ServerRequestInterface): \Psr\Http\Message\ResponseInterface $invoker */
+                public function __construct(private array $hit, private $invoker) {}
+
+                public function handle(\Psr\Http\Message\ServerRequestInterface $request): \Psr\Http\Message\ResponseInterface
+                {
+                    return ($this->invoker)($this->hit, $request);
+                }
+            };
+
+            $response = $pipeline->run($request, $terminal);
+
             \Rxn\Framework\Http\PsrAdapter::emit($response);
-            \Rxn\Framework\Observability\Events::emit(
-                new \Rxn\Framework\Observability\Event\ResponseEmitted($pairId, $response, null)
-            );
-            return;
+            if ($eventsEnabled && $pairId !== null) {
+                \Rxn\Framework\Observability\Events::emit(
+                    new \Rxn\Framework\Observability\Event\ResponseEmitted($pairId, $response)
+                );
+            }
+        } finally {
+            // Clear the request-scoped pair id so a long-running
+            // worker (Swoole / RoadRunner) doesn't leak it into the
+            // next request. The slot is intentionally process-wide
+            // (sync PHP serves one request at a time per worker),
+            // and we want it gone before the next request begins.
+            if ($eventsEnabled) {
+                \Rxn\Framework\Observability\Events::useCurrentPairId(null);
+            }
         }
+    }
 
-        $pipeline = new \Rxn\Framework\Http\Pipeline();
-        foreach ($hit['middlewares'] as $mw) {
-            $pipeline->add($mw);
-        }
-
-        $invoker ??= self::defaultHandlerInvoker(...);
-
-        // Wrap the user invoker with HandlerInvoked entered/exited
-        // events. Same `$pairId` brackets the boundary; failures
-        // propagate so the pipeline sees the original exception.
-        $observingInvoker = static function (array $hit, \Psr\Http\Message\ServerRequestInterface $req) use ($invoker, $pairId): \Psr\Http\Message\ResponseInterface {
+    /**
+     * Decorate `$invoker` with `HandlerInvoked` entered/exited
+     * events, both shared with the request's pair id. The exited
+     * event fires both on success and on throw; the throwable is
+     * re-thrown so the pipeline / global error handler still sees
+     * the original.
+     */
+    private static function wrapInvokerWithHandlerEvents(callable $invoker, string $pairId): callable
+    {
+        return static function (array $hit, \Psr\Http\Message\ServerRequestInterface $req) use ($invoker, $pairId): \Psr\Http\Message\ResponseInterface {
             $handlerLabel = self::describeHandler($hit['handler'] ?? null);
             \Rxn\Framework\Observability\Events::emit(
                 new \Rxn\Framework\Observability\Event\HandlerInvoked(
@@ -178,23 +236,6 @@ class App
                 throw $e;
             }
         };
-
-        $terminal = new class($hit, $observingInvoker) implements \Psr\Http\Server\RequestHandlerInterface {
-            /** @param callable(array, \Psr\Http\Message\ServerRequestInterface): \Psr\Http\Message\ResponseInterface $invoker */
-            public function __construct(private array $hit, private $invoker) {}
-
-            public function handle(\Psr\Http\Message\ServerRequestInterface $request): \Psr\Http\Message\ResponseInterface
-            {
-                return ($this->invoker)($this->hit, $request);
-            }
-        };
-
-        $response = $pipeline->run($request, $terminal);
-
-        \Rxn\Framework\Http\PsrAdapter::emit($response);
-        \Rxn\Framework\Observability\Events::emit(
-            new \Rxn\Framework\Observability\Event\ResponseEmitted($pairId, $response)
-        );
     }
 
     /**

--- a/src/Rxn/Framework/App.php
+++ b/src/Rxn/Framework/App.php
@@ -258,7 +258,15 @@ class App
             return $handler;
         }
         if (is_object($handler)) {
-            return $handler::class;
+            // Invokables (`__invoke`) are the common dispatcher
+            // shape — surface them as `Class::__invoke` so the
+            // span name distinguishes them from constructor-only
+            // objects of the same class. Non-invokable objects
+            // fall back to the bare class name (the caller has
+            // probably stuffed something exotic in `handler`).
+            return is_callable($handler)
+                ? $handler::class . '::__invoke'
+                : $handler::class;
         }
         return 'callable';
     }

--- a/src/Rxn/Framework/Http/Binding/Binder.php
+++ b/src/Rxn/Framework/Http/Binding/Binder.php
@@ -80,8 +80,35 @@ final class Binder
         // pre-compile, which is the whole point of profile-guided
         // dump: opcache memory pays only for hot DTOs.
         if (isset(self::$compiledCache[$class])) {
-            return (self::$compiledCache[$class])($source ?? self::gatherBag());
+            \Rxn\Framework\Observability\Events::emit(
+                new \Rxn\Framework\Observability\Event\BinderInvoked(
+                    $class,
+                    \Rxn\Framework\Observability\Event\BinderInvoked::PATH_COMPILED,
+                )
+            );
+            try {
+                $dto = (self::$compiledCache[$class])($source ?? self::gatherBag());
+            } catch (ValidationException $e) {
+                \Rxn\Framework\Observability\Events::emit(
+                    new \Rxn\Framework\Observability\Event\ValidationCompleted(
+                        $class,
+                        self::groupValidationFailures($e->errors()),
+                    )
+                );
+                throw $e;
+            }
+            \Rxn\Framework\Observability\Events::emit(
+                new \Rxn\Framework\Observability\Event\ValidationCompleted($class, [])
+            );
+            return $dto;
         }
+
+        \Rxn\Framework\Observability\Events::emit(
+            new \Rxn\Framework\Observability\Event\BinderInvoked(
+                $class,
+                \Rxn\Framework\Observability\Event\BinderInvoked::PATH_RUNTIME,
+            )
+        );
 
         $bag = $source ?? self::gatherBag();
         $ref = new \ReflectionClass($class);
@@ -137,9 +164,38 @@ final class Binder
         }
 
         if ($errors !== []) {
+            \Rxn\Framework\Observability\Events::emit(
+                new \Rxn\Framework\Observability\Event\ValidationCompleted(
+                    $class,
+                    self::groupValidationFailures($errors),
+                )
+            );
             throw new ValidationException($errors);
         }
+        \Rxn\Framework\Observability\Events::emit(
+            new \Rxn\Framework\Observability\Event\ValidationCompleted($class, [])
+        );
         return $dto;
+    }
+
+    /**
+     * Reshape `[{field, message}, ...]` (the `ValidationException`
+     * format) into `[field => list<message>]` (the
+     * `ValidationCompleted` event format). One field can fail
+     * multiple rules (e.g. min + pattern); the event groups by
+     * field so listeners can label metrics by field name without
+     * post-processing.
+     *
+     * @param  list<array{field: string, message: string}> $errors
+     * @return array<string, list<string>>
+     */
+    private static function groupValidationFailures(array $errors): array
+    {
+        $grouped = [];
+        foreach ($errors as $err) {
+            $grouped[$err['field']][] = $err['message'];
+        }
+        return $grouped;
     }
 
     /**

--- a/src/Rxn/Framework/Http/Binding/Binder.php
+++ b/src/Rxn/Framework/Http/Binding/Binder.php
@@ -79,36 +79,56 @@ final class Binder
         // the runtime walker for cold classes the user chose not to
         // pre-compile, which is the whole point of profile-guided
         // dump: opcache memory pays only for hot DTOs.
+        // Snapshot once: every emit site below skips when no
+        // dispatcher is installed, avoiding both the
+        // event-construction cost and the pair-id lookup.
+        $eventsEnabled = \Rxn\Framework\Observability\Events::enabled();
+
         if (isset(self::$compiledCache[$class])) {
-            \Rxn\Framework\Observability\Events::emit(
-                new \Rxn\Framework\Observability\Event\BinderInvoked(
-                    $class,
-                    \Rxn\Framework\Observability\Event\BinderInvoked::PATH_COMPILED,
-                )
-            );
+            if ($eventsEnabled) {
+                \Rxn\Framework\Observability\Events::emit(
+                    new \Rxn\Framework\Observability\Event\BinderInvoked(
+                        $class,
+                        \Rxn\Framework\Observability\Event\BinderInvoked::PATH_COMPILED,
+                        \Rxn\Framework\Observability\Events::currentPairId(),
+                    )
+                );
+            }
             try {
                 $dto = (self::$compiledCache[$class])($source ?? self::gatherBag());
             } catch (ValidationException $e) {
+                if ($eventsEnabled) {
+                    \Rxn\Framework\Observability\Events::emit(
+                        new \Rxn\Framework\Observability\Event\ValidationCompleted(
+                            $class,
+                            self::groupValidationFailures($e->errors()),
+                            \Rxn\Framework\Observability\Events::currentPairId(),
+                        )
+                    );
+                }
+                throw $e;
+            }
+            if ($eventsEnabled) {
                 \Rxn\Framework\Observability\Events::emit(
                     new \Rxn\Framework\Observability\Event\ValidationCompleted(
                         $class,
-                        self::groupValidationFailures($e->errors()),
+                        [],
+                        \Rxn\Framework\Observability\Events::currentPairId(),
                     )
                 );
-                throw $e;
             }
-            \Rxn\Framework\Observability\Events::emit(
-                new \Rxn\Framework\Observability\Event\ValidationCompleted($class, [])
-            );
             return $dto;
         }
 
-        \Rxn\Framework\Observability\Events::emit(
-            new \Rxn\Framework\Observability\Event\BinderInvoked(
-                $class,
-                \Rxn\Framework\Observability\Event\BinderInvoked::PATH_RUNTIME,
-            )
-        );
+        if ($eventsEnabled) {
+            \Rxn\Framework\Observability\Events::emit(
+                new \Rxn\Framework\Observability\Event\BinderInvoked(
+                    $class,
+                    \Rxn\Framework\Observability\Event\BinderInvoked::PATH_RUNTIME,
+                    \Rxn\Framework\Observability\Events::currentPairId(),
+                )
+            );
+        }
 
         $bag = $source ?? self::gatherBag();
         $ref = new \ReflectionClass($class);
@@ -164,17 +184,26 @@ final class Binder
         }
 
         if ($errors !== []) {
+            if ($eventsEnabled) {
+                \Rxn\Framework\Observability\Events::emit(
+                    new \Rxn\Framework\Observability\Event\ValidationCompleted(
+                        $class,
+                        self::groupValidationFailures($errors),
+                        \Rxn\Framework\Observability\Events::currentPairId(),
+                    )
+                );
+            }
+            throw new ValidationException($errors);
+        }
+        if ($eventsEnabled) {
             \Rxn\Framework\Observability\Events::emit(
                 new \Rxn\Framework\Observability\Event\ValidationCompleted(
                     $class,
-                    self::groupValidationFailures($errors),
+                    [],
+                    \Rxn\Framework\Observability\Events::currentPairId(),
                 )
             );
-            throw new ValidationException($errors);
         }
-        \Rxn\Framework\Observability\Events::emit(
-            new \Rxn\Framework\Observability\Event\ValidationCompleted($class, [])
-        );
         return $dto;
     }
 

--- a/src/Rxn/Framework/Http/Binding/Binder.php
+++ b/src/Rxn/Framework/Http/Binding/Binder.php
@@ -85,38 +85,40 @@ final class Binder
         $eventsEnabled = \Rxn\Framework\Observability\Events::enabled();
 
         if (isset(self::$compiledCache[$class])) {
-            if ($eventsEnabled) {
-                \Rxn\Framework\Observability\Events::emit(
-                    new \Rxn\Framework\Observability\Event\BinderInvoked(
-                        $class,
-                        \Rxn\Framework\Observability\Event\BinderInvoked::PATH_COMPILED,
-                        \Rxn\Framework\Observability\Events::currentPairId(),
-                    )
-                );
+            // Fast path when no listener is subscribed: the
+            // compiled closure runs untouched, no try/catch frame
+            // setup, no event allocations. This is the hottest
+            // path in the framework — it's worth the duplication
+            // to keep it a straight return.
+            if (!$eventsEnabled) {
+                return (self::$compiledCache[$class])($source ?? self::gatherBag());
             }
+            \Rxn\Framework\Observability\Events::emit(
+                new \Rxn\Framework\Observability\Event\BinderInvoked(
+                    $class,
+                    \Rxn\Framework\Observability\Event\BinderInvoked::PATH_COMPILED,
+                    \Rxn\Framework\Observability\Events::currentPairId(),
+                )
+            );
             try {
                 $dto = (self::$compiledCache[$class])($source ?? self::gatherBag());
             } catch (ValidationException $e) {
-                if ($eventsEnabled) {
-                    \Rxn\Framework\Observability\Events::emit(
-                        new \Rxn\Framework\Observability\Event\ValidationCompleted(
-                            $class,
-                            self::groupValidationFailures($e->errors()),
-                            \Rxn\Framework\Observability\Events::currentPairId(),
-                        )
-                    );
-                }
-                throw $e;
-            }
-            if ($eventsEnabled) {
                 \Rxn\Framework\Observability\Events::emit(
                     new \Rxn\Framework\Observability\Event\ValidationCompleted(
                         $class,
-                        [],
+                        self::groupValidationFailures($e->errors()),
                         \Rxn\Framework\Observability\Events::currentPairId(),
                     )
                 );
+                throw $e;
             }
+            \Rxn\Framework\Observability\Events::emit(
+                new \Rxn\Framework\Observability\Event\ValidationCompleted(
+                    $class,
+                    [],
+                    \Rxn\Framework\Observability\Events::currentPairId(),
+                )
+            );
             return $dto;
         }
 

--- a/src/Rxn/Framework/Http/Pipeline.php
+++ b/src/Rxn/Framework/Http/Pipeline.php
@@ -88,8 +88,18 @@ final class Pipeline implements RequestHandlerInterface
         }
         $index      = $this->index++;
         $middleware = $this->middlewares[$index];
-        $cls        = $middleware::class;
-        $pairId     = Events::newPairId();
+
+        // Gate the entire instrumentation on a dispatcher being
+        // installed: pair-id minting (random_bytes call) and event
+        // construction both happen only when there's a listener.
+        // Apps that don't subscribe pay just this one null-check
+        // per middleware hop.
+        if (!Events::enabled()) {
+            return $middleware->process($request, $this);
+        }
+
+        $cls    = $middleware::class;
+        $pairId = Events::newPairId();
         Events::emit(new MiddlewareEntered($pairId, $cls, $index, $request));
         try {
             $response = $middleware->process($request, $this);

--- a/src/Rxn/Framework/Http/Pipeline.php
+++ b/src/Rxn/Framework/Http/Pipeline.php
@@ -6,6 +6,9 @@ use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Server\MiddlewareInterface;
 use Psr\Http\Server\RequestHandlerInterface;
+use Rxn\Framework\Observability\Event\MiddlewareEntered;
+use Rxn\Framework\Observability\Event\MiddlewareExited;
+use Rxn\Framework\Observability\Events;
 
 /**
  * PSR-15 middleware pipeline. Accepts PSR-15 middlewares and a
@@ -83,7 +86,18 @@ final class Pipeline implements RequestHandlerInterface
         if ($this->index >= count($this->middlewares)) {
             return $this->terminal->handle($request);
         }
-        $middleware = $this->middlewares[$this->index++];
-        return $middleware->process($request, $this);
+        $index      = $this->index++;
+        $middleware = $this->middlewares[$index];
+        $cls        = $middleware::class;
+        $pairId     = Events::newPairId();
+        Events::emit(new MiddlewareEntered($pairId, $cls, $index, $request));
+        try {
+            $response = $middleware->process($request, $this);
+            Events::emit(new MiddlewareExited($pairId, $cls, $index, $response, null));
+            return $response;
+        } catch (\Throwable $e) {
+            Events::emit(new MiddlewareExited($pairId, $cls, $index, null, $e));
+            throw $e;
+        }
     }
 }

--- a/src/Rxn/Framework/Http/Router.php
+++ b/src/Rxn/Framework/Http/Router.php
@@ -196,9 +196,16 @@ final class Router
         // are static) skip the regex walk entirely.
         $staticHit = $this->staticRoutes[$method][$path] ?? null;
         if ($staticHit !== null) {
-            \Rxn\Framework\Observability\Events::emit(
-                new \Rxn\Framework\Observability\Event\RouteMatched($method, $staticHit->pattern, [])
-            );
+            if (\Rxn\Framework\Observability\Events::enabled()) {
+                \Rxn\Framework\Observability\Events::emit(
+                    new \Rxn\Framework\Observability\Event\RouteMatched(
+                        $method,
+                        $staticHit->pattern,
+                        [],
+                        \Rxn\Framework\Observability\Events::currentPairId(),
+                    )
+                );
+            }
             return [
                 'handler'     => $staticHit->handler,
                 'params'      => [],
@@ -219,9 +226,16 @@ final class Router
             foreach ($route->paramNames as $i => $name) {
                 $params[$name] = $matches[$i + 1];
             }
-            \Rxn\Framework\Observability\Events::emit(
-                new \Rxn\Framework\Observability\Event\RouteMatched($method, $route->pattern, $params)
-            );
+            if (\Rxn\Framework\Observability\Events::enabled()) {
+                \Rxn\Framework\Observability\Events::emit(
+                    new \Rxn\Framework\Observability\Event\RouteMatched(
+                        $method,
+                        $route->pattern,
+                        $params,
+                        \Rxn\Framework\Observability\Events::currentPairId(),
+                    )
+                );
+            }
             return [
                 'handler'     => $route->handler,
                 'params'      => $params,

--- a/src/Rxn/Framework/Http/Router.php
+++ b/src/Rxn/Framework/Http/Router.php
@@ -196,6 +196,9 @@ final class Router
         // are static) skip the regex walk entirely.
         $staticHit = $this->staticRoutes[$method][$path] ?? null;
         if ($staticHit !== null) {
+            \Rxn\Framework\Observability\Events::emit(
+                new \Rxn\Framework\Observability\Event\RouteMatched($method, $staticHit->pattern, [])
+            );
             return [
                 'handler'     => $staticHit->handler,
                 'params'      => [],
@@ -216,6 +219,9 @@ final class Router
             foreach ($route->paramNames as $i => $name) {
                 $params[$name] = $matches[$i + 1];
             }
+            \Rxn\Framework\Observability\Events::emit(
+                new \Rxn\Framework\Observability\Event\RouteMatched($method, $route->pattern, $params)
+            );
             return [
                 'handler'     => $route->handler,
                 'params'      => $params,

--- a/src/Rxn/Framework/Observability/Event/BinderInvoked.php
+++ b/src/Rxn/Framework/Observability/Event/BinderInvoked.php
@@ -1,0 +1,25 @@
+<?php declare(strict_types=1);
+
+namespace Rxn\Framework\Observability\Event;
+
+/**
+ * Emitted by `Binder::bind()` once per DTO bind. The class is the
+ * DTO FQCN; the path is `compiled` if the binder dispatched to a
+ * pre-compiled closure (post `warmFromProfile()` or `compileFor()`)
+ * or `runtime` if it walked reflection.
+ *
+ * Listeners use the path tag to track compile-cache hit ratio —
+ * the metric that tells operators whether their `dump:hot`
+ * cadence is actually keeping up with hot-DTO drift.
+ */
+final class BinderInvoked implements FrameworkEvent
+{
+    public const PATH_COMPILED = 'compiled';
+    public const PATH_RUNTIME  = 'runtime';
+
+    /** @param class-string $class */
+    public function __construct(
+        public readonly string $class,
+        public readonly string $path,
+    ) {}
+}

--- a/src/Rxn/Framework/Observability/Event/BinderInvoked.php
+++ b/src/Rxn/Framework/Observability/Event/BinderInvoked.php
@@ -11,6 +11,11 @@ namespace Rxn\Framework\Observability\Event;
  * Listeners use the path tag to track compile-cache hit ratio —
  * the metric that tells operators whether their `dump:hot`
  * cadence is actually keeping up with hot-DTO drift.
+ *
+ * `$pairId` carries the request's pair id when the bind happened
+ * inside an `App::serve()` request. It's null when `Binder::bind()`
+ * is called outside a request scope (unit tests, scripts that
+ * use the binder directly).
  */
 final class BinderInvoked implements FrameworkEvent
 {
@@ -21,5 +26,6 @@ final class BinderInvoked implements FrameworkEvent
     public function __construct(
         public readonly string $class,
         public readonly string $path,
+        public readonly ?string $pairId = null,
     ) {}
 }

--- a/src/Rxn/Framework/Observability/Event/FrameworkEvent.php
+++ b/src/Rxn/Framework/Observability/Event/FrameworkEvent.php
@@ -1,0 +1,28 @@
+<?php declare(strict_types=1);
+
+namespace Rxn\Framework\Observability\Event;
+
+/**
+ * Marker for events emitted by the framework's request lifecycle.
+ * Listeners that want to receive every framework event subscribe
+ * once on this interface; the PSR-14 ListenerProvider walks the
+ * implemented interfaces of each dispatched event so a single
+ * registration covers every concrete event type.
+ *
+ * Conventions for implementers:
+ *
+ *   - Events are immutable value objects. Listeners that need to
+ *     pair "entered" with "exited" rely on a `$pairId` carried by
+ *     both events — the dispatcher emits the same id for the
+ *     entered/exited boundary of one execution.
+ *   - Events carry only what a listener can't otherwise reach.
+ *     The PSR-7 request is included on the entry events; the
+ *     response on the exit events. Stack-bound state (the
+ *     currently-active span, the request-scoped logger) belongs in
+ *     the listener.
+ *   - No OpenTelemetry / Prometheus / vendor types appear here.
+ *     The events are the substrate; vendor listeners adapt them.
+ */
+interface FrameworkEvent
+{
+}

--- a/src/Rxn/Framework/Observability/Event/HandlerInvoked.php
+++ b/src/Rxn/Framework/Observability/Event/HandlerInvoked.php
@@ -1,0 +1,34 @@
+<?php declare(strict_types=1);
+
+namespace Rxn\Framework\Observability\Event;
+
+/**
+ * Emitted around the user handler invocation in `App::serve()`.
+ * `$pairId` brackets the `entered` and `exited` boundary the
+ * same way as the middleware events; listeners pair them by id.
+ *
+ * `$state` is the lifecycle marker:
+ *   - `entered` — handler is about to be called
+ *   - `exited`  — handler returned normally (`$throwable` null)
+ *                 or threw (`$throwable` set)
+ *
+ * `$handler` is a stringified handler descriptor (e.g.
+ * `"Acme\\Controller\\UserController::show"` or `"Closure"`),
+ * shaped for use as a span name. Apps with synthetic handlers
+ * (anonymous closures or invokables) end up with `Closure` /
+ * `__invoke` in the span tree — readable enough for the common
+ * case, and the route template from `RouteMatched` carries the
+ * disambiguating identity.
+ */
+final class HandlerInvoked implements FrameworkEvent
+{
+    public const STATE_ENTERED = 'entered';
+    public const STATE_EXITED  = 'exited';
+
+    public function __construct(
+        public readonly string $pairId,
+        public readonly string $state,
+        public readonly string $handler,
+        public readonly ?\Throwable $throwable = null,
+    ) {}
+}

--- a/src/Rxn/Framework/Observability/Event/MiddlewareEntered.php
+++ b/src/Rxn/Framework/Observability/Event/MiddlewareEntered.php
@@ -1,0 +1,25 @@
+<?php declare(strict_types=1);
+
+namespace Rxn\Framework\Observability\Event;
+
+use Psr\Http\Message\ServerRequestInterface;
+
+/**
+ * Emitted by `Pipeline::handle()` immediately before each
+ * middleware's `process()` call. Pairs with `MiddlewareExited`
+ * (same `$pairId`). One pair per middleware invocation.
+ *
+ * `$middlewareClass` is the FQCN of the middleware (anonymous
+ * classes serialise as `class@anonymous{...}`); listeners use it
+ * as the span name. `$index` is the middleware's position in the
+ * configured stack, useful for ordering / dropdowns in dashboards.
+ */
+final class MiddlewareEntered implements FrameworkEvent
+{
+    public function __construct(
+        public readonly string $pairId,
+        public readonly string $middlewareClass,
+        public readonly int $index,
+        public readonly ServerRequestInterface $request,
+    ) {}
+}

--- a/src/Rxn/Framework/Observability/Event/MiddlewareExited.php
+++ b/src/Rxn/Framework/Observability/Event/MiddlewareExited.php
@@ -1,0 +1,28 @@
+<?php declare(strict_types=1);
+
+namespace Rxn\Framework\Observability\Event;
+
+use Psr\Http\Message\ResponseInterface;
+
+/**
+ * Emitted by `Pipeline::handle()` immediately after each
+ * middleware's `process()` call returns or throws. Pairs with
+ * `MiddlewareEntered` (same `$pairId`). One pair per middleware
+ * invocation.
+ *
+ * `$response` is null when the middleware threw — `$throwable`
+ * carries the exception. Listeners close the open span and tag
+ * it with the error if any. Both fields can also be null on
+ * abnormal interpreter shutdown, but the framework itself doesn't
+ * emit such events.
+ */
+final class MiddlewareExited implements FrameworkEvent
+{
+    public function __construct(
+        public readonly string $pairId,
+        public readonly string $middlewareClass,
+        public readonly int $index,
+        public readonly ?ResponseInterface $response,
+        public readonly ?\Throwable $throwable = null,
+    ) {}
+}

--- a/src/Rxn/Framework/Observability/Event/RequestReceived.php
+++ b/src/Rxn/Framework/Observability/Event/RequestReceived.php
@@ -1,0 +1,25 @@
+<?php declare(strict_types=1);
+
+namespace Rxn\Framework\Observability\Event;
+
+use Psr\Http\Message\ServerRequestInterface;
+
+/**
+ * The first event for a request — emitted by `App::serve()` before
+ * the middleware pipeline runs. Pairs with `ResponseEmitted`
+ * (same `$pairId`).
+ *
+ * A listener building a span tree opens the root span here and
+ * uses the `traceparent` header (set by the TraceContext
+ * middleware on inbound, or generated locally) as the parent. The
+ * pair id distinguishes concurrent requests within a single
+ * worker — sync PHP serves one request per worker at a time, but
+ * Swoole / RoadRunner deployments can interleave.
+ */
+final class RequestReceived implements FrameworkEvent
+{
+    public function __construct(
+        public readonly string $pairId,
+        public readonly ServerRequestInterface $request,
+    ) {}
+}

--- a/src/Rxn/Framework/Observability/Event/ResponseEmitted.php
+++ b/src/Rxn/Framework/Observability/Event/ResponseEmitted.php
@@ -1,0 +1,26 @@
+<?php declare(strict_types=1);
+
+namespace Rxn\Framework\Observability\Event;
+
+use Psr\Http\Message\ResponseInterface;
+
+/**
+ * Last event for a request — emitted by `App::serve()` after the
+ * pipeline returns and immediately before the response is written
+ * to the wire. Pairs with `RequestReceived` (same `$pairId`).
+ *
+ * Only emitted on the success path. If the pipeline throws and
+ * the exception propagates past `App::serve()`, no
+ * `ResponseEmitted` fires — listeners infer "request died" from
+ * the absence of an exit event for the same pair id. Apps that
+ * want failed-request observability install an exception-handling
+ * middleware in the pipeline; the middleware's own
+ * `MiddlewareExited` event carries the throwable.
+ */
+final class ResponseEmitted implements FrameworkEvent
+{
+    public function __construct(
+        public readonly string $pairId,
+        public readonly ResponseInterface $response,
+    ) {}
+}

--- a/src/Rxn/Framework/Observability/Event/ResponseEmitted.php
+++ b/src/Rxn/Framework/Observability/Event/ResponseEmitted.php
@@ -6,16 +6,27 @@ use Psr\Http\Message\ResponseInterface;
 
 /**
  * Last event for a request — emitted by `App::serve()` after the
- * pipeline returns and immediately before the response is written
- * to the wire. Pairs with `RequestReceived` (same `$pairId`).
+ * response has been written to the wire. Pairs with
+ * `RequestReceived` (same `$pairId`).
  *
- * Only emitted on the success path. If the pipeline throws and
- * the exception propagates past `App::serve()`, no
- * `ResponseEmitted` fires — listeners infer "request died" from
- * the absence of an exit event for the same pair id. Apps that
- * want failed-request observability install an exception-handling
- * middleware in the pipeline; the middleware's own
- * `MiddlewareExited` event carries the throwable.
+ * Fires once per response that `App::serve()` writes:
+ *   - Successful pipeline runs (the common case).
+ *   - 404 / 405 misses (pipeline never built; psrProblem
+ *     short-circuits — listeners still want to close the
+ *     request span).
+ *
+ * Does NOT fire when an exception escapes the pipeline past
+ * `App::serve()`. Listeners infer "request died" from the
+ * absence of a `ResponseEmitted` carrying the same pair id.
+ * Apps that want fully-symmetric observability install an
+ * exception-handling middleware in the pipeline; that
+ * middleware's own `MiddlewareExited` carries the throwable.
+ *
+ * Listeners that want to instrument BEFORE the wire write
+ * (e.g. injecting a server-timing header) should hook into the
+ * outermost middleware's `MiddlewareExited` instead — that event
+ * fires after the response is built but before
+ * `PsrAdapter::emit()` writes it.
  */
 final class ResponseEmitted implements FrameworkEvent
 {

--- a/src/Rxn/Framework/Observability/Event/RouteMatched.php
+++ b/src/Rxn/Framework/Observability/Event/RouteMatched.php
@@ -15,6 +15,15 @@ namespace Rxn\Framework\Observability\Event;
  * Not emitted for unmatched routes — the absence of a
  * `RouteMatched` event between `RequestReceived` and the first
  * `MiddlewareEntered` is itself the signal.
+ *
+ * `$pairId` carries the request's pair id (the same id on the
+ * surrounding `RequestReceived` / `ResponseEmitted`) when the
+ * request flowed through `App::serve()`. Listeners use it to
+ * attribute the route to the right in-flight request on
+ * concurrent-worker setups (Swoole / RoadRunner). It's null
+ * when callers drive the Router directly without going through
+ * `App::serve()` — in that case there's no request scope to
+ * attribute to.
  */
 final class RouteMatched implements FrameworkEvent
 {
@@ -23,5 +32,6 @@ final class RouteMatched implements FrameworkEvent
         public readonly string $method,
         public readonly string $template,
         public readonly array $params,
+        public readonly ?string $pairId = null,
     ) {}
 }

--- a/src/Rxn/Framework/Observability/Event/RouteMatched.php
+++ b/src/Rxn/Framework/Observability/Event/RouteMatched.php
@@ -1,0 +1,27 @@
+<?php declare(strict_types=1);
+
+namespace Rxn\Framework\Observability\Event;
+
+/**
+ * Emitted by `Router::match()` when a route matches the incoming
+ * request. The route template is the registered string from the
+ * `#[Route]` attribute (e.g. `/users/{id:int}`); the resolved
+ * params are the placeholder values extracted from the URL.
+ *
+ * Listeners typically tag the active span with the template
+ * (low-cardinality, dashboard-friendly) and stash the params for
+ * downstream events that don't carry them.
+ *
+ * Not emitted for unmatched routes — the absence of a
+ * `RouteMatched` event between `RequestReceived` and the first
+ * `MiddlewareEntered` is itself the signal.
+ */
+final class RouteMatched implements FrameworkEvent
+{
+    /** @param array<string, string> $params */
+    public function __construct(
+        public readonly string $method,
+        public readonly string $template,
+        public readonly array $params,
+    ) {}
+}

--- a/src/Rxn/Framework/Observability/Event/RouteMatched.php
+++ b/src/Rxn/Framework/Observability/Event/RouteMatched.php
@@ -18,12 +18,15 @@ namespace Rxn\Framework\Observability\Event;
  *
  * `$pairId` carries the request's pair id (the same id on the
  * surrounding `RequestReceived` / `ResponseEmitted`) when the
- * request flowed through `App::serve()`. Listeners use it to
- * attribute the route to the right in-flight request on
- * concurrent-worker setups (Swoole / RoadRunner). It's null
- * when callers drive the Router directly without going through
- * `App::serve()` — in that case there's no request scope to
- * attribute to.
+ * request flowed through `App::serve()`. It's null when callers
+ * drive the Router directly without going through `App::serve()`
+ * — in that case there's no request scope to attribute to.
+ *
+ * The pair id is read from the process-wide static slot
+ * `Events::currentPairId()` — see the `Events` class docblock for
+ * the sync-only contract. Standard PHP SAPIs (php-fpm / mod_php
+ * / cli-server) serialise requests; coroutine runtimes (Swoole /
+ * fiber bridges) need a request-scoped pair id source instead.
  */
 final class RouteMatched implements FrameworkEvent
 {

--- a/src/Rxn/Framework/Observability/Event/ValidationCompleted.php
+++ b/src/Rxn/Framework/Observability/Event/ValidationCompleted.php
@@ -14,6 +14,10 @@ namespace Rxn\Framework\Observability\Event;
  * This is the only framework event that fires *during* an
  * exception's bubbling — it's emitted from the binder's catch
  * block and re-throws.
+ *
+ * `$pairId` carries the request's pair id when the validation
+ * happened inside an `App::serve()` request. Null when the
+ * binder is driven outside a request scope.
  */
 final class ValidationCompleted implements FrameworkEvent
 {
@@ -24,6 +28,7 @@ final class ValidationCompleted implements FrameworkEvent
     public function __construct(
         public readonly string $class,
         public readonly array $failures,
+        public readonly ?string $pairId = null,
     ) {}
 
     public function isFailure(): bool

--- a/src/Rxn/Framework/Observability/Event/ValidationCompleted.php
+++ b/src/Rxn/Framework/Observability/Event/ValidationCompleted.php
@@ -1,0 +1,33 @@
+<?php declare(strict_types=1);
+
+namespace Rxn\Framework\Observability\Event;
+
+/**
+ * Emitted by `Binder::bind()` after the DTO's validation rules
+ * have all been checked. `$failures` is empty on success;
+ * non-empty when one or more `#[Required]` / `#[Min]` / etc.
+ * rules rejected the input — even though `bind()` would have
+ * already thrown a `ValidationException` to its caller, the
+ * event still fires so listeners can capture the failed field
+ * names for metrics.
+ *
+ * This is the only framework event that fires *during* an
+ * exception's bubbling — it's emitted from the binder's catch
+ * block and re-throws.
+ */
+final class ValidationCompleted implements FrameworkEvent
+{
+    /**
+     * @param class-string         $class
+     * @param array<string, list<string>> $failures field → list of failure messages
+     */
+    public function __construct(
+        public readonly string $class,
+        public readonly array $failures,
+    ) {}
+
+    public function isFailure(): bool
+    {
+        return $this->failures !== [];
+    }
+}

--- a/src/Rxn/Framework/Observability/Events.php
+++ b/src/Rxn/Framework/Observability/Events.php
@@ -1,0 +1,76 @@
+<?php declare(strict_types=1);
+
+namespace Rxn\Framework\Observability;
+
+use Psr\EventDispatcher\EventDispatcherInterface;
+
+/**
+ * Static slot for the framework's observability dispatcher. Keeps
+ * the call sites in `Pipeline`, `Router`, `Binder`, `App::serve()`
+ * decoupled from any concrete dispatcher — they emit through
+ * `Events::emit()`, which is a no-op until the app installs one.
+ *
+ * Same posture as `RequestId` / `BearerAuth` / `TraceContext` /
+ * `DumpCache`: PHP's single-threaded request lifecycle scopes the
+ * static slot. Apps that share a worker across requests (Swoole,
+ * RoadRunner) install the dispatcher once at boot — listeners are
+ * responsible for using event payload state (e.g. `$pairId`) to
+ * separate concurrent requests rather than ambient slots.
+ *
+ *   $provider = new ListenerProvider();
+ *   $provider->listen(FrameworkEvent::class, $myListener);
+ *   Events::useDispatcher(new EventDispatcher($provider));
+ *
+ * Without an installed dispatcher, `Events::emit()` short-circuits
+ * — the event-construction cost is paid by callers but the
+ * dispatch cost is zero.
+ */
+final class Events
+{
+    private static ?EventDispatcherInterface $dispatcher = null;
+
+    /**
+     * Install the dispatcher. Pass `null` to remove (tests, or
+     * apps disabling observability after boot).
+     */
+    public static function useDispatcher(?EventDispatcherInterface $dispatcher): void
+    {
+        self::$dispatcher = $dispatcher;
+    }
+
+    /**
+     * Snapshot accessor — useful for tests and for code paths that
+     * need to dispatch a non-framework event through the same
+     * channel (e.g. an app-defined event that listeners are
+     * watching for).
+     */
+    public static function dispatcher(): ?EventDispatcherInterface
+    {
+        return self::$dispatcher;
+    }
+
+    /**
+     * Dispatch an event if a dispatcher is installed. No-op
+     * otherwise. Returns the (possibly listener-mutated) event so
+     * callers can still inspect it — useful in tests and for
+     * stoppable-event semantics.
+     */
+    public static function emit(object $event): object
+    {
+        if (self::$dispatcher === null) {
+            return $event;
+        }
+        return self::$dispatcher->dispatch($event);
+    }
+
+    /**
+     * Mint a fresh pair id. Used by the framework to bracket
+     * entered/exited events. 16 hex chars = 64 bits of entropy,
+     * collision-free for any realistic interleaving within a
+     * single worker.
+     */
+    public static function newPairId(): string
+    {
+        return bin2hex(random_bytes(8));
+    }
+}

--- a/src/Rxn/Framework/Observability/Events.php
+++ b/src/Rxn/Framework/Observability/Events.php
@@ -30,12 +30,54 @@ final class Events
     private static ?EventDispatcherInterface $dispatcher = null;
 
     /**
+     * Per-request pair id, set by `App::serve()` between
+     * `RequestReceived` and `ResponseEmitted`. Read by emit
+     * sites that don't carry the id directly (Router, Binder)
+     * so listeners on concurrent-worker setups can attribute
+     * the event to a specific in-flight request.
+     */
+    private static ?string $currentPairId = null;
+
+    /**
      * Install the dispatcher. Pass `null` to remove (tests, or
      * apps disabling observability after boot).
      */
     public static function useDispatcher(?EventDispatcherInterface $dispatcher): void
     {
         self::$dispatcher = $dispatcher;
+    }
+
+    /**
+     * True when a dispatcher is installed. Hot call sites read
+     * this BEFORE constructing event objects or calling
+     * `newPairId()` — when no dispatcher is installed, both costs
+     * are skipped entirely so apps that don't subscribe pay only
+     * one method call per emit point.
+     */
+    public static function enabled(): bool
+    {
+        return self::$dispatcher !== null;
+    }
+
+    /**
+     * Set the request-scoped pair id. Cleared (passed `null`)
+     * after the response is written, in a finally block, so a
+     * stale id doesn't leak across requests in long-running
+     * workers (Swoole / RoadRunner).
+     */
+    public static function useCurrentPairId(?string $pairId): void
+    {
+        self::$currentPairId = $pairId;
+    }
+
+    /**
+     * Read the request-scoped pair id, or null when none is set
+     * (CLI / non-`App::serve()` entry points, or after the
+     * response has been written).
+     */
+    public static function currentPairId(): ?string
+    {
+        return self::$currentPairId;
     }
 
     /**

--- a/src/Rxn/Framework/Observability/Events.php
+++ b/src/Rxn/Framework/Observability/Events.php
@@ -7,23 +7,39 @@ use Psr\EventDispatcher\EventDispatcherInterface;
 /**
  * Static slot for the framework's observability dispatcher. Keeps
  * the call sites in `Pipeline`, `Router`, `Binder`, `App::serve()`
- * decoupled from any concrete dispatcher — they emit through
- * `Events::emit()`, which is a no-op until the app installs one.
+ * decoupled from any concrete dispatcher — every emit site reads
+ * `Events::enabled()` and skips event allocation entirely when no
+ * dispatcher is installed.
  *
  * Same posture as `RequestId` / `BearerAuth` / `TraceContext` /
- * `DumpCache`: PHP's single-threaded request lifecycle scopes the
- * static slot. Apps that share a worker across requests (Swoole,
- * RoadRunner) install the dispatcher once at boot — listeners are
- * responsible for using event payload state (e.g. `$pairId`) to
- * separate concurrent requests rather than ambient slots.
+ * `DumpCache`: a process-wide static slot scoped to PHP's standard
+ * synchronous request lifecycle (one request per worker at a time).
+ *
+ * **Sync-only.** Under runtimes that interleave requests within a
+ * single PHP process (Swoole / RoadRunner / OpenSwoole / Fiber-based
+ * concurrency), the `currentPairId()` slot can be overwritten while
+ * a request's Router/Binder calls are still in flight, attributing
+ * the event to the wrong pair id. The dispatcher slot itself is
+ * fine to share — it doesn't change per-request — but the per-
+ * request pair id is not safe across coroutine boundaries. A future
+ * fiber-aware variant would thread the pair id explicitly through
+ * the call sites or store it on the PSR-7 request attribute bag.
  *
  *   $provider = new ListenerProvider();
  *   $provider->listen(FrameworkEvent::class, $myListener);
  *   Events::useDispatcher(new EventDispatcher($provider));
  *
- * Without an installed dispatcher, `Events::emit()` short-circuits
- * — the event-construction cost is paid by callers but the
- * dispatch cost is zero.
+ * Recommended pattern at the call site:
+ *
+ *   if (Events::enabled()) {
+ *       Events::emit(new MyEvent(...));   // construct only when needed
+ *   }
+ *
+ * Without an installed dispatcher, `Events::emit()` is itself a
+ * safe no-op — but the gate above also avoids constructing the
+ * event object in the first place, which matters on hot paths
+ * (per-middleware, per-bind) where an unnecessary value-object
+ * allocation adds up.
  */
 final class Events
 {
@@ -31,10 +47,14 @@ final class Events
 
     /**
      * Per-request pair id, set by `App::serve()` between
-     * `RequestReceived` and `ResponseEmitted`. Read by emit
-     * sites that don't carry the id directly (Router, Binder)
-     * so listeners on concurrent-worker setups can attribute
-     * the event to a specific in-flight request.
+     * `RequestReceived` and `ResponseEmitted` and cleared in a
+     * `finally` block when the response is written. Read by emit
+     * sites that don't carry the id directly (Router, Binder).
+     *
+     * Sync-only — see the class docblock. Under coroutine-based
+     * runtimes (Swoole, fibers) two requests can be in flight in
+     * the same process and the slot doesn't separate them. PHP's
+     * standard SAPI serialises requests so the slot is safe there.
      */
     private static ?string $currentPairId = null;
 

--- a/src/Rxn/Framework/Tests/Observability/AppServeEventsTest.php
+++ b/src/Rxn/Framework/Tests/Observability/AppServeEventsTest.php
@@ -1,0 +1,240 @@
+<?php declare(strict_types=1);
+
+namespace Rxn\Framework\Tests\Observability;
+
+use Nyholm\Psr7\Response;
+use PHPUnit\Framework\TestCase;
+use Rxn\Framework\App;
+use Rxn\Framework\Event\EventDispatcher;
+use Rxn\Framework\Event\ListenerProvider;
+use Rxn\Framework\Http\Router;
+use Rxn\Framework\Observability\Event\FrameworkEvent;
+use Rxn\Framework\Observability\Event\HandlerInvoked;
+use Rxn\Framework\Observability\Event\RequestReceived;
+use Rxn\Framework\Observability\Event\ResponseEmitted;
+use Rxn\Framework\Observability\Event\RouteMatched;
+use Rxn\Framework\Observability\Events;
+
+/**
+ * Integration tests for `App::serve()` event emission.
+ *
+ * These tests run `App::serve()` against synthetic `$_SERVER`
+ * state and capture the response with `ob_start()` so the
+ * `PsrAdapter::emit()` call (echo + header()) is harmless in the
+ * CLI/PHPUnit context. Five things on trial:
+ *
+ *   1. The success path emits `RequestReceived` →
+ *      `RouteMatched` → `HandlerInvoked(entered)` →
+ *      `HandlerInvoked(exited)` → `ResponseEmitted`, all
+ *      sharing a single pair id where applicable.
+ *   2. The 404 / 405 miss path emits `RequestReceived` and
+ *      `ResponseEmitted` (no `RouteMatched`, no
+ *      `HandlerInvoked`) — the listener can still close the
+ *      request span.
+ *   3. The pair id flows into Router events via
+ *      `Events::currentPairId()`.
+ *   4. The pair-id slot is cleared in `finally`, so a subsequent
+ *      request doesn't see the previous request's id.
+ *   5. With no dispatcher installed, `App::serve()` doesn't mint
+ *      a pair id and emits nothing — verifying the no-op
+ *      guarantee that the docstring promises.
+ */
+final class AppServeEventsTest extends TestCase
+{
+    /** @var list<FrameworkEvent> */
+    private array $captured = [];
+    /** @var array<string, mixed> */
+    private array $serverBackup = [];
+
+    protected function setUp(): void
+    {
+        $this->captured     = [];
+        $this->serverBackup = $_SERVER;
+
+        $provider = new ListenerProvider();
+        $provider->listen(FrameworkEvent::class, function (object $e): void {
+            $this->captured[] = $e;
+        });
+        Events::useDispatcher(new EventDispatcher($provider));
+    }
+
+    protected function tearDown(): void
+    {
+        Events::useDispatcher(null);
+        Events::useCurrentPairId(null);
+        $_SERVER = $this->serverBackup;
+    }
+
+    public function testSuccessfulRequestEmitsFullEventTree(): void
+    {
+        $router = new Router();
+        $router->get('/users/{id:int}', static fn (array $params) => new Response(
+            200,
+            ['Content-Type' => 'application/json'],
+            json_encode(['id' => $params['id']]),
+        ));
+
+        $this->setRequest('GET', '/users/42');
+
+        ob_start();
+        try {
+            App::serve($router, static function (array $hit, $req) {
+                $handler = $hit['handler'];
+                return $handler($hit['params'] ?? [], $req);
+            });
+        } finally {
+            ob_end_clean();
+        }
+
+        $types = array_map(static fn ($e) => $e::class, $this->captured);
+        $this->assertSame(
+            [
+                RequestReceived::class,
+                RouteMatched::class,
+                HandlerInvoked::class, // entered
+                HandlerInvoked::class, // exited
+                ResponseEmitted::class,
+            ],
+            $types,
+            'event ordering must match the documented lifecycle',
+        );
+
+        /** @var RequestReceived $req */
+        $req = $this->captured[0];
+        /** @var RouteMatched $route */
+        $route = $this->captured[1];
+        /** @var HandlerInvoked $entered */
+        $entered = $this->captured[2];
+        /** @var HandlerInvoked $exited */
+        $exited = $this->captured[3];
+        /** @var ResponseEmitted $resp */
+        $resp = $this->captured[4];
+
+        $pairId = $req->pairId;
+        $this->assertNotSame('', $pairId);
+        $this->assertSame($pairId, $route->pairId, 'RouteMatched must carry the request pair id');
+        $this->assertSame($pairId, $entered->pairId);
+        $this->assertSame($pairId, $exited->pairId);
+        $this->assertSame($pairId, $resp->pairId);
+
+        $this->assertSame('/users/{id:int}', $route->template);
+        $this->assertSame(['id' => '42'], $route->params);
+
+        $this->assertSame(HandlerInvoked::STATE_ENTERED, $entered->state);
+        $this->assertSame(HandlerInvoked::STATE_EXITED, $exited->state);
+        $this->assertNull($exited->throwable);
+
+        $this->assertSame(200, $resp->response->getStatusCode());
+    }
+
+    public function testRouteMissEmitsRequestReceivedAndResponseEmittedOnly(): void
+    {
+        $router = new Router();
+        $router->get('/users/{id:int}', static fn () => new Response(200));
+        // Different path — listener should still see request bookends.
+        $this->setRequest('GET', '/no/such/path');
+
+        ob_start();
+        try {
+            App::serve($router);
+        } finally {
+            ob_end_clean();
+        }
+
+        $types = array_map(static fn ($e) => $e::class, $this->captured);
+        $this->assertSame(
+            [RequestReceived::class, ResponseEmitted::class],
+            $types,
+            '404 path: just request bookends, no RouteMatched/Handler events',
+        );
+
+        /** @var RequestReceived $req */
+        $req = $this->captured[0];
+        /** @var ResponseEmitted $resp */
+        $resp = $this->captured[1];
+
+        $this->assertSame($req->pairId, $resp->pairId);
+        $this->assertSame(404, $resp->response->getStatusCode());
+    }
+
+    public function testMethodMismatchEmits405WithoutRouteMatched(): void
+    {
+        $router = new Router();
+        $router->get('/users/me', static fn () => new Response(200));
+        $this->setRequest('POST', '/users/me');
+
+        ob_start();
+        try {
+            App::serve($router);
+        } finally {
+            ob_end_clean();
+        }
+
+        /** @var ResponseEmitted $resp */
+        $resp = $this->captured[1] ?? null;
+        $this->assertNotNull($resp);
+        $this->assertSame(405, $resp->response->getStatusCode());
+
+        $hadRouteMatched = false;
+        foreach ($this->captured as $ev) {
+            if ($ev instanceof RouteMatched) {
+                $hadRouteMatched = true;
+            }
+        }
+        $this->assertFalse($hadRouteMatched, '405 must NOT emit RouteMatched (nothing matched)');
+    }
+
+    public function testPairIdSlotIsClearedAfterRequest(): void
+    {
+        $router = new Router();
+        $router->get('/x', static fn () => new Response(200));
+        $this->setRequest('GET', '/x');
+
+        ob_start();
+        try {
+            App::serve($router);
+        } finally {
+            ob_end_clean();
+        }
+
+        // After the request, the slot must be back to null —
+        // otherwise the next request in a long-running worker
+        // would inherit the previous pair id.
+        $this->assertNull(Events::currentPairId());
+    }
+
+    public function testNoEventsEmittedWhenDispatcherIsAbsent(): void
+    {
+        // Detach the dispatcher BEFORE calling serve(). This is
+        // the production no-op path: apps that don't subscribe
+        // pay nothing.
+        Events::useDispatcher(null);
+
+        $router = new Router();
+        $router->get('/x', static fn () => new Response(200));
+        $this->setRequest('GET', '/x');
+
+        ob_start();
+        try {
+            App::serve($router, static function (array $hit, $req) {
+                return ($hit['handler'])($hit['params'] ?? [], $req);
+            });
+        } finally {
+            ob_end_clean();
+        }
+
+        $this->assertSame([], $this->captured);
+        $this->assertNull(Events::currentPairId(), 'no slot mutation when disabled');
+    }
+
+    private function setRequest(string $method, string $path): void
+    {
+        $_SERVER['REQUEST_METHOD'] = $method;
+        $_SERVER['REQUEST_URI']    = $path;
+        $_SERVER['HTTP_HOST']      = 'test.local';
+        $_SERVER['SERVER_NAME']    = 'test.local';
+        $_SERVER['SERVER_PORT']    = '80';
+        $_SERVER['HTTPS']          = '';
+        $_SERVER['QUERY_STRING']   = '';
+    }
+}

--- a/src/Rxn/Framework/Tests/Observability/AppServeEventsTest.php
+++ b/src/Rxn/Framework/Tests/Observability/AppServeEventsTest.php
@@ -203,6 +203,48 @@ final class AppServeEventsTest extends TestCase
         $this->assertNull(Events::currentPairId());
     }
 
+    public function testHandlerLabelForInvokableObjectIncludesInvokeSuffix(): void
+    {
+        // Invokable controllers (__invoke) are a common dispatcher
+        // shape — the span name needs to distinguish them from
+        // plain objects of the same class. The describeHandler()
+        // contract calls these out with the `::__invoke` suffix.
+        $invokable = new class {
+            public function __invoke(array $params, $req): \Psr\Http\Message\ResponseInterface
+            {
+                return new Response(200);
+            }
+        };
+        $invokableClass = $invokable::class;
+
+        $router = new Router();
+        $router->get('/inv', $invokable);
+        $this->setRequest('GET', '/inv');
+
+        ob_start();
+        try {
+            App::serve($router, static function (array $hit, $req) {
+                return ($hit['handler'])($hit['params'] ?? [], $req);
+            });
+        } finally {
+            ob_end_clean();
+        }
+
+        $entered = null;
+        foreach ($this->captured as $ev) {
+            if ($ev instanceof HandlerInvoked && $ev->state === HandlerInvoked::STATE_ENTERED) {
+                $entered = $ev;
+                break;
+            }
+        }
+        $this->assertNotNull($entered);
+        $this->assertSame(
+            $invokableClass . '::__invoke',
+            $entered->handler,
+            'invokable handlers must surface as Class::__invoke for span readability',
+        );
+    }
+
     public function testNoEventsEmittedWhenDispatcherIsAbsent(): void
     {
         // Detach the dispatcher BEFORE calling serve(). This is

--- a/src/Rxn/Framework/Tests/Observability/BinderEmitsObservabilityEventsTest.php
+++ b/src/Rxn/Framework/Tests/Observability/BinderEmitsObservabilityEventsTest.php
@@ -1,0 +1,136 @@
+<?php declare(strict_types=1);
+
+namespace Rxn\Framework\Tests\Observability;
+
+use PHPUnit\Framework\TestCase;
+use Rxn\Framework\Codegen\Profile\BindProfile;
+use Rxn\Framework\Event\EventDispatcher;
+use Rxn\Framework\Event\ListenerProvider;
+use Rxn\Framework\Http\Binding\Binder;
+use Rxn\Framework\Http\Binding\ValidationException;
+use Rxn\Framework\Observability\Event\BinderInvoked;
+use Rxn\Framework\Observability\Event\FrameworkEvent;
+use Rxn\Framework\Observability\Event\ValidationCompleted;
+use Rxn\Framework\Observability\Events;
+use Rxn\Framework\Tests\Http\Binding\Fixture\CreateProduct;
+
+/**
+ * `Binder::bind()` emits two events per call: `BinderInvoked`
+ * (with path tag) and `ValidationCompleted`. Both fire on the
+ * runtime walker AND the compiled fast path; the path tag tells
+ * a listener which fired so they can compute compile-cache hit
+ * ratio.
+ */
+final class BinderEmitsObservabilityEventsTest extends TestCase
+{
+    /** @var list<FrameworkEvent> */
+    private array $captured = [];
+
+    protected function setUp(): void
+    {
+        $this->captured = [];
+        BindProfile::reset();
+        Binder::clearCache();
+        $provider = new ListenerProvider();
+        $provider->listen(FrameworkEvent::class, function (object $e): void {
+            $this->captured[] = $e;
+        });
+        Events::useDispatcher(new EventDispatcher($provider));
+    }
+
+    protected function tearDown(): void
+    {
+        Events::useDispatcher(null);
+        BindProfile::reset();
+        Binder::clearCache();
+    }
+
+    public function testRuntimePathEmitsBinderInvokedAndValidationCompleted(): void
+    {
+        Binder::bind(CreateProduct::class, ['name' => 'Widget', 'price' => 9]);
+
+        $this->assertCount(2, $this->captured);
+
+        /** @var BinderInvoked $invoked */
+        $invoked = $this->captured[0];
+        $this->assertInstanceOf(BinderInvoked::class, $invoked);
+        $this->assertSame(CreateProduct::class, $invoked->class);
+        $this->assertSame(BinderInvoked::PATH_RUNTIME, $invoked->path);
+
+        /** @var ValidationCompleted $valid */
+        $valid = $this->captured[1];
+        $this->assertInstanceOf(ValidationCompleted::class, $valid);
+        $this->assertFalse($valid->isFailure());
+        $this->assertSame([], $valid->failures);
+    }
+
+    public function testCompiledPathEmitsBinderInvokedWithCompiledTag(): void
+    {
+        Binder::compileFor(CreateProduct::class);
+        // First bind() now goes through the in-memory compiled
+        // closure — the BinderInvoked event must reflect that.
+        $this->captured = []; // discard compileFor's own event noise (none)
+
+        Binder::bind(CreateProduct::class, ['name' => 'X', 'price' => 1]);
+
+        $this->assertCount(2, $this->captured);
+        /** @var BinderInvoked $invoked */
+        $invoked = $this->captured[0];
+        $this->assertSame(BinderInvoked::PATH_COMPILED, $invoked->path);
+    }
+
+    public function testValidationFailureGroupsByFieldName(): void
+    {
+        try {
+            Binder::bind(CreateProduct::class, ['name' => '', 'price' => 'not-a-number']);
+            $this->fail('expected ValidationException');
+        } catch (ValidationException) {
+            // expected
+        }
+
+        $valid = null;
+        foreach ($this->captured as $ev) {
+            if ($ev instanceof ValidationCompleted) {
+                $valid = $ev;
+            }
+        }
+        $this->assertNotNull($valid);
+        $this->assertTrue($valid->isFailure());
+        // Both failed fields are present and grouped:
+        $this->assertArrayHasKey('name', $valid->failures);
+        $this->assertArrayHasKey('price', $valid->failures);
+        $this->assertContainsOnly('string', $valid->failures['name']);
+        $this->assertContainsOnly('string', $valid->failures['price']);
+    }
+
+    public function testCompiledPathStillEmitsValidationCompletedOnFailure(): void
+    {
+        // The compiled binder throws ValidationException directly;
+        // the framework wraps it so ValidationCompleted still fires
+        // before the exception escapes to the caller. Otherwise
+        // metrics for the compiled path would silently lose
+        // failures.
+        Binder::compileFor(CreateProduct::class);
+        $this->captured = [];
+
+        try {
+            Binder::bind(CreateProduct::class, ['name' => '', 'price' => -1]);
+            $this->fail('expected ValidationException');
+        } catch (ValidationException) {
+            // expected
+        }
+
+        $sawInvoked = false;
+        $sawValid   = false;
+        foreach ($this->captured as $ev) {
+            if ($ev instanceof BinderInvoked && $ev->path === BinderInvoked::PATH_COMPILED) {
+                $sawInvoked = true;
+            }
+            if ($ev instanceof ValidationCompleted && $ev->isFailure()) {
+                $sawValid = true;
+            }
+        }
+        $this->assertTrue($sawInvoked, 'compiled-path BinderInvoked must fire even on failure');
+        $this->assertTrue($sawValid, 'ValidationCompleted must fire even when the compiled binder throws');
+    }
+}

--- a/src/Rxn/Framework/Tests/Observability/EventsTest.php
+++ b/src/Rxn/Framework/Tests/Observability/EventsTest.php
@@ -95,6 +95,33 @@ final class EventsTest extends TestCase
         $this->assertTrue($stoppedEvent->stopped);
     }
 
+    public function testEnabledReportsDispatcherPresence(): void
+    {
+        // Used by hot call sites (Pipeline, Router, Binder, App)
+        // to skip pair-id minting + event construction entirely
+        // when no dispatcher is installed. Without this gate the
+        // no-subscriber case still pays for `random_bytes(8)` on
+        // every middleware hop.
+        $this->assertFalse(Events::enabled());
+
+        Events::useDispatcher(new EventDispatcher(new ListenerProvider()));
+        $this->assertTrue(Events::enabled());
+
+        Events::useDispatcher(null);
+        $this->assertFalse(Events::enabled());
+    }
+
+    public function testCurrentPairIdRoundTrips(): void
+    {
+        $this->assertNull(Events::currentPairId());
+
+        Events::useCurrentPairId('abc123');
+        $this->assertSame('abc123', Events::currentPairId());
+
+        Events::useCurrentPairId(null);
+        $this->assertNull(Events::currentPairId());
+    }
+
     public function testCustomDispatcherImplementationIsAccepted(): void
     {
         // Apps wiring their own PSR-14 dispatcher (e.g. a Symfony

--- a/src/Rxn/Framework/Tests/Observability/EventsTest.php
+++ b/src/Rxn/Framework/Tests/Observability/EventsTest.php
@@ -1,0 +1,117 @@
+<?php declare(strict_types=1);
+
+namespace Rxn\Framework\Tests\Observability;
+
+use PHPUnit\Framework\TestCase;
+use Psr\EventDispatcher\EventDispatcherInterface;
+use Rxn\Framework\Event\EventDispatcher;
+use Rxn\Framework\Event\ListenerProvider;
+use Rxn\Framework\Observability\Event\FrameworkEvent;
+use Rxn\Framework\Observability\Events;
+
+/**
+ * Direct unit tests for the static dispatch slot. Two things on
+ * trial:
+ *
+ *  1. `emit()` is a no-op (and returns the event unchanged) when
+ *     no dispatcher is installed — every framework call site
+ *     relies on this so adding the events doesn't impose runtime
+ *     cost on apps that don't subscribe.
+ *  2. `emit()` flows through to the installed dispatcher and
+ *     returns whatever the dispatcher returns (so listener-mutated
+ *     events are visible to the caller).
+ */
+final class EventsTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        Events::useDispatcher(null);
+    }
+
+    protected function tearDown(): void
+    {
+        Events::useDispatcher(null);
+    }
+
+    public function testEmitIsNoopWhenNoDispatcherInstalled(): void
+    {
+        $event = new class implements FrameworkEvent {};
+        // No exception, returns the same event unchanged.
+        $this->assertSame($event, Events::emit($event));
+    }
+
+    public function testEmitDispatchesThroughInstalledDispatcher(): void
+    {
+        $captured = [];
+        $provider = new ListenerProvider();
+        $provider->listen(FrameworkEvent::class, static function (object $e) use (&$captured): void {
+            $captured[] = $e;
+        });
+        Events::useDispatcher(new EventDispatcher($provider));
+
+        $event = new class implements FrameworkEvent {};
+        Events::emit($event);
+
+        $this->assertSame([$event], $captured);
+    }
+
+    public function testDispatcherAccessorReturnsInstalledDispatcher(): void
+    {
+        $this->assertNull(Events::dispatcher());
+        $dispatcher = new EventDispatcher(new ListenerProvider());
+        Events::useDispatcher($dispatcher);
+        $this->assertSame($dispatcher, Events::dispatcher());
+    }
+
+    public function testNewPairIdIsHexAndDistinct(): void
+    {
+        $a = Events::newPairId();
+        $b = Events::newPairId();
+        $this->assertSame(16, strlen($a));
+        $this->assertMatchesRegularExpression('/^[0-9a-f]{16}$/', $a);
+        $this->assertNotSame($a, $b);
+    }
+
+    public function testEmitReturnsDispatcherReturnValueForStoppableSemantics(): void
+    {
+        // PSR-14 dispatchers return the (possibly mutated) event so
+        // callers can chain. Our static helper preserves that.
+        $stoppedEvent = new class implements FrameworkEvent, \Psr\EventDispatcher\StoppableEventInterface {
+            public bool $stopped = false;
+            public function isPropagationStopped(): bool { return $this->stopped; }
+        };
+
+        $provider = new ListenerProvider();
+        $provider->listen(FrameworkEvent::class, static function (object $e): void {
+            $e->stopped = true; // mutate
+        });
+        $provider->listen(FrameworkEvent::class, static function (): void {
+            throw new \LogicException('listener after a stopped event must not run');
+        });
+        Events::useDispatcher(new EventDispatcher($provider));
+
+        $returned = Events::emit($stoppedEvent);
+        $this->assertSame($stoppedEvent, $returned);
+        $this->assertTrue($stoppedEvent->stopped);
+    }
+
+    public function testCustomDispatcherImplementationIsAccepted(): void
+    {
+        // Apps wiring their own PSR-14 dispatcher (e.g. a Symfony
+        // Messenger bridge) plug in via the same slot.
+        $custom = new class implements EventDispatcherInterface {
+            public array $seen = [];
+            public function dispatch(object $event): object
+            {
+                $this->seen[] = $event;
+                return $event;
+            }
+        };
+        Events::useDispatcher($custom);
+
+        $event = new class implements FrameworkEvent {};
+        Events::emit($event);
+
+        $this->assertSame([$event], $custom->seen);
+    }
+}

--- a/src/Rxn/Framework/Tests/Observability/PipelineEmitsMiddlewareEventsTest.php
+++ b/src/Rxn/Framework/Tests/Observability/PipelineEmitsMiddlewareEventsTest.php
@@ -1,0 +1,176 @@
+<?php declare(strict_types=1);
+
+namespace Rxn\Framework\Tests\Observability;
+
+use Nyholm\Psr7\Response;
+use Nyholm\Psr7\ServerRequest;
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\MiddlewareInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+use Rxn\Framework\Event\EventDispatcher;
+use Rxn\Framework\Event\ListenerProvider;
+use Rxn\Framework\Http\Pipeline;
+use Rxn\Framework\Observability\Event\FrameworkEvent;
+use Rxn\Framework\Observability\Event\MiddlewareEntered;
+use Rxn\Framework\Observability\Event\MiddlewareExited;
+use Rxn\Framework\Observability\Events;
+
+/**
+ * Integration tests for `Pipeline` event emission. Three things
+ * on trial:
+ *
+ *   1. Each middleware in the stack produces exactly one
+ *      Entered/Exited pair, and they share a `pairId`.
+ *   2. The `index` field matches the middleware's position in the
+ *      stack.
+ *   3. When a middleware throws, an Exited event STILL fires —
+ *      the listener can close the open span instead of leaking
+ *      it.
+ */
+final class PipelineEmitsMiddlewareEventsTest extends TestCase
+{
+    /** @var list<FrameworkEvent> */
+    private array $captured = [];
+
+    protected function setUp(): void
+    {
+        $this->captured = [];
+        $provider = new ListenerProvider();
+        $provider->listen(FrameworkEvent::class, function (object $e): void {
+            $this->captured[] = $e;
+        });
+        Events::useDispatcher(new EventDispatcher($provider));
+    }
+
+    protected function tearDown(): void
+    {
+        Events::useDispatcher(null);
+    }
+
+    public function testEmitsOneEnteredExitedPairPerMiddlewareInOrder(): void
+    {
+        $pipeline = (new Pipeline())
+            ->add($this->makeMiddleware('A'))
+            ->add($this->makeMiddleware('B'));
+
+        $terminal = $this->terminalReturning(new Response(200));
+        $pipeline->run(new ServerRequest('GET', '/'), $terminal);
+
+        $this->assertCount(4, $this->captured, '2 middlewares × Entered+Exited = 4 events');
+
+        // Order: A entered, B entered, B exited, A exited
+        // (LIFO: each middleware completes before the previous returns).
+        [$e0, $e1, $e2, $e3] = $this->captured;
+
+        $this->assertInstanceOf(MiddlewareEntered::class, $e0);
+        $this->assertInstanceOf(MiddlewareEntered::class, $e1);
+        $this->assertInstanceOf(MiddlewareExited::class, $e2);
+        $this->assertInstanceOf(MiddlewareExited::class, $e3);
+
+        $this->assertSame(0, $e0->index, 'first Entered is index 0');
+        $this->assertSame(1, $e1->index, 'second Entered is index 1');
+        $this->assertSame(1, $e2->index, 'inner Exited matches inner Entered');
+        $this->assertSame(0, $e3->index, 'outer Exited matches outer Entered');
+    }
+
+    public function testEnteredAndExitedShareAPairId(): void
+    {
+        $pipeline = (new Pipeline())
+            ->add($this->makeMiddleware('Only'));
+
+        $pipeline->run(new ServerRequest('GET', '/'), $this->terminalReturning(new Response(200)));
+
+        $this->assertCount(2, $this->captured);
+        /** @var MiddlewareEntered $entered */
+        $entered = $this->captured[0];
+        /** @var MiddlewareExited $exited */
+        $exited  = $this->captured[1];
+
+        $this->assertNotSame('', $entered->pairId);
+        $this->assertSame($entered->pairId, $exited->pairId);
+    }
+
+    public function testExitedFiresEvenWhenMiddlewareThrows(): void
+    {
+        // A listener building a span tree must always close every
+        // span it opened — so even when the middleware throws,
+        // `MiddlewareExited` must fire (with `$throwable` set).
+        $thrower = new class implements MiddlewareInterface {
+            public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
+            {
+                throw new \RuntimeException('boom');
+            }
+        };
+        $pipeline = (new Pipeline())->add($thrower);
+
+        try {
+            $pipeline->run(new ServerRequest('GET', '/'), $this->terminalReturning(new Response(200)));
+            $this->fail('exception was expected to propagate');
+        } catch (\RuntimeException) {
+            // expected
+        }
+
+        $this->assertCount(2, $this->captured);
+        /** @var MiddlewareExited $exited */
+        $exited = $this->captured[1];
+        $this->assertNull($exited->response, 'no response when middleware threw');
+        $this->assertNotNull($exited->throwable);
+        $this->assertSame('boom', $exited->throwable->getMessage());
+    }
+
+    public function testMiddlewareClassFieldIsTheConcreteFqcn(): void
+    {
+        $named = new class implements MiddlewareInterface {
+            public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
+            {
+                return $handler->handle($request);
+            }
+        };
+        $cls      = $named::class;
+        $pipeline = (new Pipeline())->add($named);
+        $pipeline->run(new ServerRequest('GET', '/'), $this->terminalReturning(new Response(200)));
+
+        /** @var MiddlewareEntered $entered */
+        $entered = $this->captured[0];
+        $this->assertSame($cls, $entered->middlewareClass);
+    }
+
+    public function testNoEventsEmittedWhenDispatcherIsAbsent(): void
+    {
+        // The real call sites all flow through `Events::emit()`,
+        // which short-circuits when no dispatcher is installed.
+        // Belt-and-braces: tear it down and verify Pipeline still
+        // works (and silently doesn't try to dispatch).
+        Events::useDispatcher(null);
+
+        $pipeline = (new Pipeline())->add($this->makeMiddleware('A'));
+        $response = $pipeline->run(new ServerRequest('GET', '/'), $this->terminalReturning(new Response(204)));
+
+        $this->assertSame(204, $response->getStatusCode());
+        $this->assertSame([], $this->captured);
+    }
+
+    private function makeMiddleware(string $tag): MiddlewareInterface
+    {
+        return new class($tag) implements MiddlewareInterface {
+            public function __construct(private string $tag) {}
+            public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
+            {
+                return $handler->handle($request->withAttribute('mw-' . $this->tag, true));
+            }
+        };
+    }
+
+    private function terminalReturning(ResponseInterface $response): RequestHandlerInterface
+    {
+        return new class($response) implements RequestHandlerInterface {
+            public function __construct(private ResponseInterface $response) {}
+            public function handle(ServerRequestInterface $request): ResponseInterface
+            {
+                return $this->response;
+            }
+        };
+    }
+}

--- a/src/Rxn/Framework/Tests/Observability/RouterEmitsRouteMatchedTest.php
+++ b/src/Rxn/Framework/Tests/Observability/RouterEmitsRouteMatchedTest.php
@@ -1,0 +1,90 @@
+<?php declare(strict_types=1);
+
+namespace Rxn\Framework\Tests\Observability;
+
+use PHPUnit\Framework\TestCase;
+use Rxn\Framework\Event\EventDispatcher;
+use Rxn\Framework\Event\ListenerProvider;
+use Rxn\Framework\Http\Router;
+use Rxn\Framework\Observability\Event\FrameworkEvent;
+use Rxn\Framework\Observability\Event\RouteMatched;
+use Rxn\Framework\Observability\Events;
+
+/**
+ * `Router::match()` emits `RouteMatched` on success — both the
+ * static-path fast lane and the regex bucket. No event fires on
+ * a miss (so listeners can detect "no route" by absence).
+ */
+final class RouterEmitsRouteMatchedTest extends TestCase
+{
+    /** @var list<FrameworkEvent> */
+    private array $captured = [];
+
+    protected function setUp(): void
+    {
+        $this->captured = [];
+        $provider = new ListenerProvider();
+        $provider->listen(RouteMatched::class, function (object $e): void {
+            $this->captured[] = $e;
+        });
+        Events::useDispatcher(new EventDispatcher($provider));
+    }
+
+    protected function tearDown(): void
+    {
+        Events::useDispatcher(null);
+    }
+
+    public function testStaticRouteMatchEmitsTemplateAndEmptyParams(): void
+    {
+        $router = new Router();
+        $router->get('/users/me', static fn () => null);
+
+        $hit = $router->match('GET', '/users/me');
+        $this->assertNotNull($hit);
+
+        $this->assertCount(1, $this->captured);
+        /** @var RouteMatched $event */
+        $event = $this->captured[0];
+        $this->assertSame('GET', $event->method);
+        $this->assertSame('/users/me', $event->template);
+        $this->assertSame([], $event->params);
+    }
+
+    public function testDynamicRouteMatchEmitsExtractedParams(): void
+    {
+        $router = new Router();
+        $router->get('/users/{id:int}', static fn () => null);
+
+        $hit = $router->match('GET', '/users/42');
+        $this->assertNotNull($hit);
+
+        $this->assertCount(1, $this->captured);
+        /** @var RouteMatched $event */
+        $event = $this->captured[0];
+        $this->assertSame('/users/{id:int}', $event->template);
+        $this->assertSame(['id' => '42'], $event->params);
+    }
+
+    public function testNoEventOnRouteMiss(): void
+    {
+        $router = new Router();
+        $router->get('/users/me', static fn () => null);
+
+        $hit = $router->match('GET', '/no/such/path');
+        $this->assertNull($hit);
+        $this->assertSame([], $this->captured);
+    }
+
+    public function testNoEventWhenMethodMismatchOnly(): void
+    {
+        // POST against a GET-only route is a 405 in the caller's
+        // frame, but `match()` returns null and no RouteMatched
+        // event fires (because no route matched).
+        $router = new Router();
+        $router->get('/users/me', static fn () => null);
+
+        $this->assertNull($router->match('POST', '/users/me'));
+        $this->assertSame([], $this->captured);
+    }
+}


### PR DESCRIPTION
## Summary

Eight first-party events emitted from the framework's request lifecycle, dispatched through PSR-14. Apps subscribe a single listener on the `FrameworkEvent` marker interface and receive the lot — request bookends, per-middleware brackets, route-match metadata, binder + validation, handler brackets — without per-component instrumentation.

This is the foundation for [horizons.md](docs/horizons.md) theme 2.1 (OpenTelemetry spans) and 2.2 (Prometheus metrics). Both are listeners over this channel; this PR ships the substrate so each becomes a thin shim instead of a full instrumentation project. Realises a new horizons line, **2.0 — observability event surface**.

## What's in the PR

- **`Rxn\Framework\Observability\Events`** — static dispatch slot. `useDispatcher()` installs a PSR-14 dispatcher (no-op until installed); `enabled()` is the gate hot call sites read before constructing event objects; `emit()` short-circuits when no dispatcher is set; `newPairId()` mints entered/exited brackets; `currentPairId()`/`useCurrentPairId()` is the request-scoped slot for cross-component correlation.
- **`Rxn\Framework\Observability\Event\FrameworkEvent`** — marker interface. Listeners that want every event subscribe once on this; the PSR-14 ListenerProvider walks implemented interfaces during dispatch.
- **Eight concrete events** under `Observability\Event\*`:
  - `RequestReceived` / `ResponseEmitted` — request bookends, paired by id
  - `MiddlewareEntered` / `MiddlewareExited` — one pair per middleware, with `\$index`; exit fires on throw with `\$throwable`
  - `RouteMatched` — template + extracted params, on both static and regex routes; carries `pairId`
  - `BinderInvoked` — with `path` tag (`compiled` | `runtime`) for compile-cache hit-ratio metrics; carries `pairId`
  - `ValidationCompleted` — failures grouped by field name; fires on success AND failure, both runtime and compiled binder paths; carries `pairId`
  - `HandlerInvoked` — entered / exited brackets for the user handler
- **Dispatch wiring** in `Pipeline::handle`, `Router::match`, `Binder::bind`, `App::serve`. All emit sites guard on `Events::enabled()` before constructing events or minting pair ids — apps that don't subscribe pay one bool read per emit point.

## Cost

- **Per emit point when no dispatcher installed:** one `Events::enabled()` bool read. The event object is NOT constructed; `random_bytes(8)` is NOT called. Apps that don't subscribe pay roughly nothing per request hop.
- **Per emit with no-op listener:** event-object allocation + one method call + iterator walk (~50 ns).
- **Hottest path preservation:** `Binder::bind()`'s compiled fast path returns the closure invocation directly when observability is disabled — no `try/catch` frame, no intermediate `\$dto` assignment.
- **No new dependencies.** Leans on the existing PSR-14 wiring.
- **Sync-only contract.** The `currentPairId()` slot is a process-wide static (same posture as `RequestId` / `BearerAuth` / `TraceContext`). Standard PHP SAPIs (php-fpm / mod_php) serialise requests so the slot is safe; coroutine runtimes (Swoole / fibers) need a request-scoped pair id source instead — the docstring calls this out.

## How apps wire it

\`\`\`php
\$provider   = new ListenerProvider();
\$dispatcher = new EventDispatcher(\$provider);

// Single registration covers every concrete event:
\$provider->listen(FrameworkEvent::class, \$myListener);

// Or target a specific event:
\$provider->listen(ValidationCompleted::class, function (ValidationCompleted \$e): void {
    if (\$e->isFailure()) {
        \$myMetrics->increment('validation_failures', \$e->failures);
    }
});

Events::useDispatcher(\$dispatcher);
\`\`\`

## Tests (27 observability)

- **8 Events helper unit** — no-op without dispatcher, dispatch through, accessor, pair-id format, stoppable semantics, custom dispatcher, `enabled()` gate, `currentPairId()` round-trip
- **5 Pipeline integration** — pair per middleware, ordered, pair-id consistency, exit-on-throw, FQCN populated, no-op without dispatcher
- **4 Router integration** — static path, dynamic params, miss, method-mismatch
- **4 Binder integration** — runtime path, compiled path, failure grouping by field, compiled path emits on failure too
- **6 App::serve integration** — full success path event tree, 404 miss path, 405 method-mismatch path, pair-id slot cleared in finally, no-op without dispatcher, invokable handler label

Suite **712 → 739 / 1598**, all green. Master merged in to pick up the recent `davidwyly/rxn` package rename.

## Test plan

- [x] \`vendor/bin/phpunit --testsuite=framework\` — full suite green (739 / 1598)
- [x] \`php -l\` lint of every modified file
- [x] No regressions in Pipeline / Router / Binder behaviour
- [x] Events fire silently when no dispatcher installed (Pipeline test verifies this directly)
- [x] CHANGELOG + horizons.md + README test counts agree