### PR TITLE
chore: ship as davidwyly/rxn library, not davidwyly/sample app

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,8 @@
 {
-  "name": "davidwyly/sample",
-  "description": "Rxn PHP Sample Project",
+  "name": "davidwyly/rxn",
+  "description": "Rxn — an opinionated, PSR-15-native JSON-only API micro-framework for PHP 8.2+. Schema-compiled DTO binding, RFC 7807 default, ~13K LOC.",
   "license": "MIT",
+  "keywords": ["framework", "api", "json", "psr-7", "psr-15", "openapi", "rfc-7807", "rxn"],
   "autoload": {
     "psr-4": {
       "Rxn\\": "src/Rxn/"
@@ -35,8 +36,23 @@
     "davidwyly/rxn-orm": "^0.1"
   },
   "suggest": {
-    "davidwyly/rxn-orm": "^0.1 \u2014 Rxn's query builder + ActiveRecord-shaped layer. Required only when you use `Rxn\\Framework\\Data\\Database::run()` or `Rxn\\Framework\\Model\\ActiveRecord` (and the `bin/bench` builder cases). Apps using Rxn purely for routing / DTO binding / middleware don't need this \u2014 install it when you reach for the Data / Model layer.",
-    "psr/simple-cache": "^3.0 \u2014 required only when using `Psr16IdempotencyStore` to plug an existing PSR-16 cache (Redis / Memcached / APCu) into the Idempotency middleware. Apps using `FileIdempotencyStore` (the default) don't need this."
+    "davidwyly/rxn-orm": "^0.1 — Rxn's query builder + ActiveRecord-shaped layer. Required only when you use `Rxn\\Framework\\Data\\Database::run()` or `Rxn\\Framework\\Model\\ActiveRecord` (and the `bin/bench` builder cases). Apps using Rxn purely for routing / DTO binding / middleware don't need this — install it when you reach for the Data / Model layer.",
+    "psr/simple-cache": "^3.0 — required only when using `Psr16IdempotencyStore` to plug an existing PSR-16 cache (Redis / Memcached / APCu) into the Idempotency middleware. Apps using `FileIdempotencyStore` (the default) don't need this."
+  },
+  "archive": {
+    "exclude": [
+      "/app",
+      "/examples",
+      "/public",
+      "/docker",
+      "/docker-compose.yml",
+      "/docker-compose.env.example",
+      "/bench",
+      "/.github",
+      "/.codeclimate.yml",
+      "/.bash_aliases",
+      "/CONTRIBUTING.md"
+    ]
   },
   "scripts": {
     "test": "phpunit"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "ca59634b4bdac3912fc6bc7ebdebafa9",
+    "content-hash": "069b570b3c3770085706e598ceb41dae",
     "packages": [
         {
             "name": "nyholm/psr7",
@@ -2497,7 +2497,8 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": "^8.2"
+        "php": "^8.2",
+        "ext-pdo": "*"
     },
     "platform-dev": {},
     "plugin-api-version": "2.9.0"


### PR DESCRIPTION
## Summary

The package was historically named `davidwyly/sample` with description "Rxn PHP Sample Project" — accurate to the early days when the repo was meant to be cloned as a starter, not consumed as a library. That shape is no longer the intent: the framework lives at `src/Rxn/Framework/*` and is the actual product.

This PR fixes the package identity:

- Renames `davidwyly/sample` → `davidwyly/rxn` (matches repo URL, namespace, README framing).
- Updates description from "Rxn PHP Sample Project" to a framework-positioning one.
- Adds packagist keywords (`framework`, `api`, `json`, `psr-7`, `psr-15`, `openapi`, `rfc-7807`, `rxn`).
- Adds `archive.exclude` so released artefacts ship the library only:
  - `app/`, `examples/`, `public/`, `docker/`, `docker-compose.yml`, `docker-compose.env.example` — sample-app demo scaffolding
  - `bench/`, `.github/`, `.codeclimate.yml`, `.bash_aliases`, `CONTRIBUTING.md` — dev-time tooling

## What this enables

- `composer require davidwyly/rxn` installs the framework cleanly — no demo dirs, no docker stack, no contributor scaffolding.
- Sibling plugins (the planned `davidwyly/rxn-observe`) can `require: davidwyly/rxn` by name in their composer manifest — same vcs-import pattern that's already used for `davidwyly/rxn-orm`.
- The repo's source layout is unchanged: `app/` and `examples/` continue to act as the worked-example reference for contributors and humans cloning the repo.

## Test plan

- [x] `composer validate --strict` — clean
- [x] `composer update --lock` — content-hash refreshed, no dep changes
- [x] `vendor/bin/phpunit --testsuite=framework` — 712 tests, 1510 assertions, all green
- [x] No source-code references to `davidwyly/sample` remain (`grep` clean)