### PR TITLE
chore: note rxn-observe plugin as the theme 2.1 OTel consumer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,13 @@ dependency — they're plain value objects, so apps that don't
 subscribe pay zero runtime cost beyond a static-slot null check
 per emit.
 
+**Consumer:** the `OpenTelemetryListener` for theme 2.1 lives in
+the [`davidwyly/rxn-observe`](https://github.com/davidwyly/rxn-observe)
+plugin, not in core — keeps the framework's composer manifest
+free of OTel-SDK dependencies. Apps that want span trees
+`composer require davidwyly/rxn-observe`; apps that don't pay
+nothing.
+
 #### Added
 
 - **`Rxn\Framework\Observability\Events`** static helper:

--- a/README.md
+++ b/README.md
@@ -23,7 +23,11 @@ one error envelope.
 
 The ORM / query builder lives in a separate package —
 [`davidwyly/rxn-orm`](https://github.com/davidwyly/rxn-orm) — pulled
-in automatically via Composer.
+in automatically via Composer. OpenTelemetry / observability
+listeners live in
+[`davidwyly/rxn-observe`](https://github.com/davidwyly/rxn-observe)
+— opt-in via `composer require`, plugs into the framework's PSR-14
+event surface.
 
 ## At a glance
 
@@ -307,6 +311,8 @@ Test counts:
 - **Rxn framework:** 739 tests / 1598 assertions (`vendor/bin/phpunit`).
 - **[`davidwyly/rxn-orm`](https://github.com/davidwyly/rxn-orm)**
   (query builder): 68 tests / 132 assertions, run in that repo.
+- **[`davidwyly/rxn-observe`](https://github.com/davidwyly/rxn-observe)**
+  (OpenTelemetry listener): 9 tests / 26 assertions, run in that repo.
 
 Cross-framework comparison harness
 ([`bench/compare/`](bench/compare/)) benchmarks Rxn against Slim 4,

--- a/composer.json
+++ b/composer.json
@@ -37,6 +37,7 @@
   },
   "suggest": {
     "davidwyly/rxn-orm": "^0.1 — Rxn's query builder + ActiveRecord-shaped layer. Required only when you use `Rxn\\Framework\\Data\\Database::run()` or `Rxn\\Framework\\Model\\ActiveRecord` (and the `bin/bench` builder cases). Apps using Rxn purely for routing / DTO binding / middleware don't need this — install it when you reach for the Data / Model layer.",
+    "davidwyly/rxn-observe": "^0.1 — OpenTelemetry / observability listeners for the framework's PSR-14 event surface (`Rxn\\Framework\\Observability\\Event\\*`). Drop the `OpenTelemetryListener` in and every request emits a span tree (root request → middleware children → handler), with binder + validation as span events. Apps that don't need distributed tracing don't install this — the framework's own emit path is a one-bool-read no-op without a dispatcher.",
     "psr/simple-cache": "^3.0 — required only when using `Psr16IdempotencyStore` to plug an existing PSR-16 cache (Redis / Memcached / APCu) into the Idempotency middleware. Apps using `FileIdempotencyStore` (the default) don't need this."
   },
   "archive": {

--- a/docs/horizons.md
+++ b/docs/horizons.md
@@ -243,42 +243,35 @@ projects.
 
 ---
 
-### 2.1 OpenTelemetry spans via PSR-14
+### 2.1 OpenTelemetry spans via PSR-14 — REALIZED
 
-**Claim:** Every middleware, route, binder, validator emits an
-OpenTelemetry span via a built-in PSR-14 listener. Toggle with
-one config flag.
+Lives in the [`davidwyly/rxn-observe`](https://github.com/davidwyly/rxn-observe)
+plugin, not in core. The plugin's `Rxn\Observe\OpenTelemetryListener`
+subscribes to the framework's `FrameworkEvent` interface (theme 2.0)
+and translates each event into the matching OTel call: root request
+span, per-middleware children, handler span, route metadata, binder
++ validation as span events.
 
-**Mechanism:** Internal events:
-- `RequestReceived` (in `Pipeline::run`)
-- `MiddlewareEntered` / `MiddlewareExited` (per-middleware,
-  injected via the Pipeline)
-- `RouteMatched` (after `Router::match`)
-- `BinderInvoked` (around `Binder::bindRequest`)
-- `ValidationCompleted`
-- `HandlerInvoked` (start of the user handler)
-- `ResponseEmitted` (at `PsrAdapter::emit`)
+**Why a plugin, not core:** A first-party OTel listener inside core
+would have pulled `open-telemetry/api` (and effectively `sdk`) into
+every Rxn install — including apps that don't need distributed
+tracing. The plugin pattern matches `davidwyly/rxn-orm`: core stays
+lean, the integration ships separately, the framework's `composer
+suggest` block documents how to opt in.
 
-A built-in `OpenTelemetryListener` subscribes to all of these,
-opens / closes spans, propagates context. Apps that don't
-configure an OTel exporter pay a no-op cost (the listener
-checks).
+**Cost reality:** ~200 LOC of listener code + 9 integration tests
+in the plugin repo. The framework-side cost (theme 2.0) was the
+event surface itself; the listener is a thin shim on top.
 
-**Cost:** ~400 LOC for the events + listener. Zero new
-dependencies if the user provides an OTel SDK; the listener
-type-hints `Psr\Log\LoggerInterface`-style on the OTel
-contracts.
+**Status:** Shipped. Span tree forms correctly against the OTel
+SDK + `InMemoryExporter` in the plugin's test suite. The Jaeger /
+Honeycomb walkthrough is a follow-up validation step — the same
+listener feeds any OTLP-speaking collector via whichever exporter
+the app installs.
 
-**Distinctiveness:** The five PSRs already provide the bones.
-Rxn just has to ship the listener. **No other PHP framework
-ships first-party OTel integration that Just Works** — Symfony
-needs `OpenTelemetryBundle`, Laravel has third-party packages,
-Slim has nothing native.
-
-**Ship signal:** Trace a real request end-to-end through Jaeger
-or Honeycomb. If the span tree is readable without further
-configuration, ship. If it requires per-app annotation, the
-event surface needs more thought first.
+**Distinctiveness still holds:** No PHP framework ships
+first-party OTel integration that Just Works. `rxn-observe` is the
+listener; Rxn core's event surface is the integration point.
 
 ---
 


### PR DESCRIPTION
## Summary

Closes the loop opened in PR #62: the observability event surface (theme 2.0) is now consumed by the [`davidwyly/rxn-observe`](https://github.com/davidwyly/rxn-observe) plugin — horizons theme 2.1 (OpenTelemetry spans via PSR-14) is **realised** via the plugin rather than baked into core.

The split keeps the framework's composer manifest free of OTel-SDK dependencies. Same pattern as `davidwyly/rxn-orm`.

## Changes

- **`composer.json`**: adds `davidwyly/rxn-observe` to the `suggest` block. Apps that want span trees `composer require davidwyly/rxn-observe`; apps that don't pay nothing (framework's own emit path is a one-bool-read no-op without a dispatcher installed).
- **`README.md`**: introduces the plugin alongside the existing `rxn-orm` reference; adds `rxn-observe`'s test count (9 / 26) to the cross-repo CI summary.
- **`docs/horizons.md`**: theme 2.1 now marked **REALIZED** with a pointer to the plugin. The "first-party OTel that Just Works" claim still holds — the plugin IS first-party, just not bundled into core.
- **`CHANGELOG.md`**: appends a "Consumer" note in the existing observability event surface section pointing at the plugin.

## What this addresses

The bloat concern raised mid-PR-#62: events without consumers are dead weight. With `rxn-observe` shipped as a separate package, those events now have a consumer that proves they earn their keep, AND the framework didn't have to absorb the OTel SDK as a hard dep.

## Test plan

- [x] `composer validate` — clean
- [x] `vendor/bin/phpunit --testsuite=framework` — 739 / 1598, no regressions
- [x] No source-code changes; doc + composer-manifest only
- [x] Plugin repo (https://github.com/davidwyly/rxn-observe) live, public, 9 / 26 tests green against the OTel SDK + InMemoryExporter