### PR TITLE
feat(examples): quickstart app demonstrating the modern Rxn shape

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,32 +39,16 @@ jobs:
 
       - name: PHP lint (find syntax errors)
         run: |
-          find src public app -name '*.php' -print0 \
+          find src bin examples -name '*.php' -print0 \
             | xargs -0 -n1 -P4 php -l > /dev/null
 
       - name: Run PHPUnit
         run: vendor/bin/phpunit
 
   integration:
-    name: Integration (HTTP + MySQL)
+    name: Integration (HTTP smoke against examples/quickstart)
     runs-on: ubuntu-latest
     timeout-minutes: 5
-
-    services:
-      mysql:
-        image: mysql:8.0
-        env:
-          MYSQL_ROOT_PASSWORD: test_root
-          MYSQL_DATABASE: rxn_app
-          MYSQL_USER: app_user
-          MYSQL_PASSWORD: test_pw
-        ports:
-          - 3306:3306
-        options: >-
-          --health-cmd="mysqladmin ping -uroot -ptest_root --silent"
-          --health-interval=10s
-          --health-timeout=5s
-          --health-retries=10
 
     steps:
       - uses: actions/checkout@v4
@@ -73,75 +57,89 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: '8.3'
-          extensions: pdo_mysql
           coverage: none
           tools: composer:v2
 
       - name: Install dependencies
         run: composer install --prefer-dist --no-progress --no-interaction
 
-      - name: Wait for MySQL
+      - name: Start php -S serving examples/quickstart
         run: |
-          for i in $(seq 1 30); do
-            if mysqladmin ping -h127.0.0.1 -uapp_user -ptest_pw --silent; then
-              echo "MySQL is ready"
-              break
-            fi
-            echo "Waiting for MySQL... ($i/30)"
-            sleep 2
-          done
-
-      - name: Configure .env
-        run: |
-          cat > app/Config/.env <<'EOF'
-          ENVIRONMENT=local
-          APP_NAMESPACE=Organization\Product\
-          APP_TIMEZONE=UTC
-          APP_USE_RXN_ORM=1
-          APP_USE_MULTIBYTE=1
-          APP_USE_FILE_CACHING=0
-          APP_USE_QUERY_CACHING=0
-          APP_USE_IO_SANITIZATION=0
-          APP_ENABLE_DATABASES=read,write
-          APP_DISABLE_SERVICES=Stats,Utility
-          DATABASE_READ_HOST=127.0.0.1
-          DATABASE_READ_NAME=rxn_app
-          DATABASE_READ_USERNAME=app_user
-          DATABASE_READ_PASSWORD=test_pw
-          DATABASE_READ_CHARSET=utf8
-          DATABASE_WRITE_HOST=127.0.0.1
-          DATABASE_WRITE_NAME=rxn_app
-          DATABASE_WRITE_USERNAME=app_user
-          DATABASE_WRITE_PASSWORD=test_pw
-          DATABASE_WRITE_CHARSET=utf8
-          TEST_OAUTH_CONSUMER_KEY=1
-          TEST_OAUTH_CONSUMER_SECRET=1
-          TEST_OAUTH_TOKEN_KEY=1
-          TEST_OAUTH_TOKEN_SECRET=1
-          EOF
-
-      - name: Start PHP server
-        run: |
-          php -S 127.0.0.1:8080 public/index.php > /tmp/server.log 2>&1 &
+          php -S 127.0.0.1:8080 -t examples/quickstart/public > /tmp/server.log 2>&1 &
           echo $! > /tmp/server.pid
-          sleep 2
+          # Give the server a moment to bind. The quickstart is
+          # boot-free (no DB, no .env), so 1s is generous.
+          sleep 1
 
-      - name: Smoke request — GET /v1.1/smoke/ping
+      - name: Smoke — GET /health
+        run: |
+          body=$(mktemp)
+          status=$(curl -sS -o "$body" -w "%{http_code}" http://127.0.0.1:8080/health)
+          echo "HTTP $status"
+          cat "$body"; echo
+          test "$status" = "200"
+          grep -q '"status":"ok"' "$body"
+
+      - name: Smoke — GET /products (empty list)
+        run: |
+          body=$(mktemp)
+          status=$(curl -sS -o "$body" -w "%{http_code}" http://127.0.0.1:8080/products)
+          echo "HTTP $status"
+          cat "$body"; echo
+          test "$status" = "200"
+          grep -q '"data":\[\]' "$body"
+
+      - name: Smoke — POST /products without auth → 401 Problem Details
         run: |
           body=$(mktemp)
           status=$(curl -sS -o "$body" -w "%{http_code}" \
-            "http://127.0.0.1:8080/?params=v1.1/smoke/ping")
+            -X POST -H 'Content-Type: application/json' \
+            -d '{"name":"X","price":1}' \
+            http://127.0.0.1:8080/products)
           echo "HTTP $status"
-          echo "--- body ---"
-          cat "$body"
-          echo
-          echo "--- server log ---"
-          cat /tmp/server.log || true
-          echo
+          cat "$body"; echo
+          test "$status" = "401"
+          grep -q '"title":"Unauthorized"' "$body"
 
-          test "$status" = "200"
-          grep -q '"ok"' "$body"
-          grep -q '"success"' "$body"
+      - name: Smoke — POST /products with auth + valid DTO → 201
+        run: |
+          body=$(mktemp)
+          status=$(curl -sS -o "$body" -w "%{http_code}" \
+            -X POST -H 'Authorization: Bearer demo' -H 'Content-Type: application/json' \
+            -d '{"name":"Widget","price":9,"status":"published"}' \
+            http://127.0.0.1:8080/products)
+          echo "HTTP $status"
+          cat "$body"; echo
+          test "$status" = "201"
+          grep -q '"name":"Widget"' "$body"
+
+      - name: Smoke — POST /products invalid DTO → 422 with errors[]
+        run: |
+          body=$(mktemp)
+          status=$(curl -sS -o "$body" -w "%{http_code}" \
+            -X POST -H 'Authorization: Bearer demo' -H 'Content-Type: application/json' \
+            -d '{"name":"","price":-1,"status":"weird"}' \
+            http://127.0.0.1:8080/products)
+          echo "HTTP $status"
+          cat "$body"; echo
+          test "$status" = "422"
+          grep -q '"errors":\[' "$body"
+          grep -q '"field":"name"' "$body"
+          grep -q '"field":"price"' "$body"
+          grep -q '"field":"status"' "$body"
+
+      - name: Smoke — GET /products/abc → typed-constraint reject (404 JSON)
+        run: |
+          body=$(mktemp)
+          status=$(curl -sS -o "$body" -w "%{http_code}" http://127.0.0.1:8080/products/abc)
+          echo "HTTP $status"
+          cat "$body"; echo
+          test "$status" = "404"
+          grep -q '"title":"Not Found"' "$body"
+
+      - name: Server log
+        if: always()
+        run: cat /tmp/server.log || true
 
       - name: Stop server
         if: always()

--- a/.gitignore
+++ b/.gitignore
@@ -57,3 +57,6 @@ Thumbs.db
 # PHPUnit cache
 /.phpunit.cache/
 /.phpunit.result.cache
+
+# Quickstart example's file-backed JSON store (created at request time)
+/var/

--- a/README.md
+++ b/README.md
@@ -261,11 +261,11 @@ handlers — the framework itself stays out of that decision.
 
 ### Worked example — `examples/quickstart/`
 
-210 LOC across three files exercising the full modern stack:
+270 LOC across three files exercising the full modern stack:
 DTO binding + attribute validation, BearerAuth, RequestId,
 HealthCheck, typed route constraints (`{id:int}`), RFC 7807
-Problem Details on every failure path. File-backed JSON repo so
-no database is needed.
+Problem Details on every failure path. File-backed JSON repo
+(flock-protected) so no database is needed.
 
 ```bash
 php -S 127.0.0.1:9871 -t examples/quickstart/public

--- a/README.md
+++ b/README.md
@@ -259,6 +259,21 @@ Caddy / Apache for production. Apps that need DI / config /
 logging wire those at the composition root and inject them into
 handlers — the framework itself stays out of that decision.
 
+### Worked example — `examples/quickstart/`
+
+210 LOC across three files exercising the full modern stack:
+DTO binding + attribute validation, BearerAuth, RequestId,
+HealthCheck, typed route constraints (`{id:int}`), RFC 7807
+Problem Details on every failure path. File-backed JSON repo so
+no database is needed.
+
+```bash
+php -S 127.0.0.1:9871 -t examples/quickstart/public
+```
+
+See [`examples/quickstart/README.md`](examples/quickstart/README.md)
+for the full curl walkthrough.
+
 ### CI / cross-framework comparison
 
 CI runs lint + phpunit against PHP 8.2, 8.3, and 8.4

--- a/examples/quickstart/README.md
+++ b/examples/quickstart/README.md
@@ -1,0 +1,120 @@
+# Quickstart — `examples/quickstart/`
+
+A minimal Rxn app exercising the modern shape end-to-end:
+`App::serve(Router)` entry, pattern routing, PSR-15 middleware
+chain, DTO binding + attribute validation, RFC 7807 Problem
+Details on every failure path.
+
+210 LOC across three files (one DTO, one file-backed JSON repo,
+one entry point) plus this README. No database, no Docker — runs
+on bare PHP. State persists in `var/quickstart-products.json` at
+the repo root (gitignored).
+
+## Run
+
+```bash
+composer install
+php -S 127.0.0.1:9871 -t examples/quickstart/public
+```
+
+In another shell, watch the framework's identity show up across
+five paths:
+
+### 1. Health check
+
+```bash
+curl http://127.0.0.1:9871/health
+# → 200 {"data":{"status":"ok","checks":{"repo":{"status":"ok"}}},"meta":{"status":200}}
+```
+
+`HealthCheck::register()` registers the route + closure; the
+returned `{data, meta}` array becomes the JSON envelope.
+
+### 2. List (no auth)
+
+```bash
+curl http://127.0.0.1:9871/products
+# → 200 {"data":[]}
+# Note: X-Request-Id header injected by the RequestId middleware.
+```
+
+### 3. Create (auth required, DTO validation)
+
+```bash
+curl -X POST http://127.0.0.1:9871/products \
+     -H 'Authorization: Bearer demo' \
+     -H 'Content-Type: application/json' \
+     -d '{"name":"Widget","price":9,"status":"published"}'
+# → 201 {"data":{"id":1,"name":"Widget","price":9,"status":"published"},"meta":{"status":201}}
+```
+
+### 4. Validation failure — every error at once
+
+```bash
+curl -X POST http://127.0.0.1:9871/products \
+     -H 'Authorization: Bearer demo' \
+     -H 'Content-Type: application/json' \
+     -d '{"name":"","price":-1,"status":"weird"}'
+# → 422 application/problem+json
+#   {
+#     "type":"about:blank",
+#     "title":"Unprocessable Entity",
+#     "status":422,
+#     "errors":[
+#       {"field":"name","message":"is required"},
+#       {"field":"price","message":"must be >= 0"},
+#       {"field":"status","message":"must be one of draft,published,archived"}
+#     ]
+#   }
+```
+
+Every failure surfaces in one response — clients fixing a form
+don't round-trip three times to discover three problems.
+
+### 5. Auth failure
+
+```bash
+curl -X POST http://127.0.0.1:9871/products \
+     -H 'Content-Type: application/json' \
+     -d '{"name":"X","price":1}'
+# → 401 application/problem+json {"type":"about:blank","title":"Unauthorized","status":401,...}
+```
+
+`BearerAuth` short-circuits before the handler runs.
+
+## What this demonstrates
+
+| Framework feature | Where it shows up |
+|---|---|
+| `App::serve(Router)` boot-free entry | `public/index.php`, last line |
+| Pattern routing + typed constraints | `/products/{id:int}` — non-numeric URLs fall through to 404 |
+| Per-route middleware | `->middleware($auth, new RequestId())` |
+| DTO binding + attribute validation | `Binder::bindRequest(CreateProduct::class, $request)` |
+| Schema as truth | `CreateProduct` drives runtime binding, validation, and the OpenAPI generator (run `bin/rxn openapi --ns=Example --root=examples/quickstart`) |
+| RFC 7807 default | Every failure is `application/problem+json` |
+| In-memory storage swap-in | `ProductRepo` is ~25 LOC; replace with `rxn-orm` for SQL |
+
+## What this *doesn't* demonstrate
+
+- No database. For storage, install
+  [`davidwyly/rxn-orm`](https://github.com/davidwyly/rxn-orm) and
+  swap `ProductRepo` for a query-builder or ActiveRecord-backed
+  implementation.
+- No observability. For span trees, install
+  [`davidwyly/rxn-observe`](https://github.com/davidwyly/rxn-observe)
+  and register `OpenTelemetryListener` on the framework's PSR-14
+  event bus.
+- No idempotency middleware (the `Idempotency` middleware needs
+  a storage backend; out of scope for a single-process quickstart).
+
+## Layout
+
+```
+examples/quickstart/
+├── README.md           ← this file
+├── public/
+│   └── index.php       ← entry point, ~80 LOC
+└── src/
+    ├── CreateProduct.php   ← DTO with validation attributes
+    └── ProductRepo.php     ← in-memory repo
+```

--- a/examples/quickstart/README.md
+++ b/examples/quickstart/README.md
@@ -5,10 +5,11 @@ A minimal Rxn app exercising the modern shape end-to-end:
 chain, DTO binding + attribute validation, RFC 7807 Problem
 Details on every failure path.
 
-210 LOC across three files (one DTO, one file-backed JSON repo,
+270 LOC across three files (one DTO, one file-backed JSON repo,
 one entry point) plus this README. No database, no Docker — runs
 on bare PHP. State persists in `var/quickstart-products.json` at
-the repo root (gitignored).
+the repo root (gitignored), with `flock`-protected writes so the
+example survives `php-fpm`-style concurrent workers honestly.
 
 ## Run
 
@@ -92,7 +93,7 @@ curl -X POST http://127.0.0.1:9871/products \
 | DTO binding + attribute validation | `Binder::bindRequest(CreateProduct::class, $request)` |
 | Schema as truth | `CreateProduct` drives runtime binding, validation, and the OpenAPI generator (run `bin/rxn openapi --ns=Example --root=examples/quickstart`) |
 | RFC 7807 default | Every failure is `application/problem+json` |
-| In-memory storage swap-in | `ProductRepo` is ~25 LOC; replace with `rxn-orm` for SQL |
+| File-backed storage swap-in | `ProductRepo` is ~120 LOC of JSON-over-`flock` so the quickstart works without a database; replace with `rxn-orm` for SQL |
 
 ## What this *doesn't* demonstrate
 
@@ -116,5 +117,5 @@ examples/quickstart/
 │   └── index.php       ← entry point, ~80 LOC
 └── src/
     ├── CreateProduct.php   ← DTO with validation attributes
-    └── ProductRepo.php     ← in-memory repo
+    └── ProductRepo.php     ← file-backed JSON repo (flock-protected)
 ```

--- a/examples/quickstart/public/index.php
+++ b/examples/quickstart/public/index.php
@@ -15,6 +15,17 @@
  * curl recipes.
  */
 
+use Example\CreateProduct;
+use Example\ProductRepo;
+use Psr\Http\Message\ServerRequestInterface;
+use Rxn\Framework\App;
+use Rxn\Framework\Http\Binding\Binder;
+use Rxn\Framework\Http\Binding\ValidationException;
+use Rxn\Framework\Http\Health\HealthCheck;
+use Rxn\Framework\Http\Middleware\BearerAuth;
+use Rxn\Framework\Http\Middleware\RequestId;
+use Rxn\Framework\Http\Router;
+
 require __DIR__ . '/../../../vendor/autoload.php';
 
 // Local autoload for the example's own classes (Example\CreateProduct,
@@ -33,17 +44,9 @@ spl_autoload_register(function (string $class): void {
     }
 });
 
-use Example\CreateProduct;
-use Example\ProductRepo;
-use Rxn\Framework\App;
-use Rxn\Framework\Http\Binding\Binder;
-use Rxn\Framework\Http\Binding\ValidationException;
-use Rxn\Framework\Http\Health\HealthCheck;
-use Rxn\Framework\Http\Middleware\BearerAuth;
-use Rxn\Framework\Http\Middleware\RequestId;
-use Rxn\Framework\Http\Router;
-
-// In-memory storage. Static through `php -S`'s long-lived process.
+// File-backed JSON store (var/quickstart-products.json at the repo
+// root). Survives across requests under php -S, php-fpm, etc.
+// Real apps swap this for an rxn-orm-backed implementation.
 $repo = new ProductRepo();
 
 $router = new Router();
@@ -64,34 +67,44 @@ $auth = new BearerAuth(
     fn (string $token) => $token === 'demo' ? ['id' => 1, 'name' => 'Demo'] : null,
 );
 
-// Read routes. RequestId middleware injects an X-Request-Id
-// header on the response (and surfaces it via `RequestId::current()`
-// for downstream code).
-$router->get('/products', fn (): array => ['data' => $repo->all()])
-    ->middleware(new RequestId());
+// Read routes. Handler signatures match the default invoker's
+// `(params, request)` contract — even where unused, declaring
+// them documents what gets passed in. RequestId middleware
+// injects an X-Request-Id header on the response.
+$router->get(
+    '/products',
+    static fn (array $params, ServerRequestInterface $request): array
+        => ['data' => $repo->all()],
+)->middleware(new RequestId());
 
-$router->get('/products/{id:int}', function (array $params) use ($repo): array {
-    $product = $repo->find((int) $params['id']);
-    if ($product === null) {
-        return ['meta' => ['status' => 404, 'title' => 'Not Found']];
-    }
-    return ['data' => $product];
-})->middleware(new RequestId());
+$router->get(
+    '/products/{id:int}',
+    static function (array $params, ServerRequestInterface $request) use ($repo): array {
+        $product = $repo->find((int) $params['id']);
+        if ($product === null) {
+            return ['meta' => ['status' => 404, 'title' => 'Not Found']];
+        }
+        return ['data' => $product];
+    },
+)->middleware(new RequestId());
 
 // Write route — authenticated. Binder hydrates + validates the
 // DTO; ValidationException rolls up every failure into one 422
 // response (RFC 7807 Problem Details), no one-at-a-time loop.
-$router->post('/products', function (array $params, $request) use ($repo): array {
-    try {
-        $dto = Binder::bindRequest(CreateProduct::class, $request);
-    } catch (ValidationException $e) {
-        return ['meta' => [
-            'status' => 422,
-            'title'  => 'Unprocessable Entity',
-            'errors' => $e->errors(),
-        ]];
-    }
-    return ['data' => $repo->create($dto), 'meta' => ['status' => 201]];
-})->middleware($auth, new RequestId());
+$router->post(
+    '/products',
+    static function (array $params, ServerRequestInterface $request) use ($repo): array {
+        try {
+            $dto = Binder::bindRequest(CreateProduct::class, $request);
+        } catch (ValidationException $e) {
+            return ['meta' => [
+                'status' => 422,
+                'title'  => 'Unprocessable Entity',
+                'errors' => $e->errors(),
+            ]];
+        }
+        return ['data' => $repo->create($dto), 'meta' => ['status' => 201]];
+    },
+)->middleware($auth, new RequestId());
 
 App::serve($router);

--- a/examples/quickstart/public/index.php
+++ b/examples/quickstart/public/index.php
@@ -1,0 +1,97 @@
+<?php declare(strict_types=1);
+
+/**
+ * Quickstart entry point. Demonstrates the modern Rxn shape:
+ *
+ *   $router = new Router();
+ *   $router->get('/path', $handler)->middleware($mw);
+ *   App::serve($router);
+ *
+ * Run with:
+ *
+ *   php -S 127.0.0.1:9871 -t examples/quickstart/public
+ *
+ * Then exercise from another shell — see the example's README for
+ * curl recipes.
+ */
+
+require __DIR__ . '/../../../vendor/autoload.php';
+
+// Local autoload for the example's own classes (Example\CreateProduct,
+// Example\ProductRepo). The framework's own composer autoload doesn't
+// know about this path; rather than ship a separate composer.json
+// for the quickstart, a tiny PSR-4 stub keeps the example
+// dependency-free at install time.
+spl_autoload_register(function (string $class): void {
+    if (!str_starts_with($class, 'Example\\')) {
+        return;
+    }
+    $relative = substr($class, strlen('Example\\'));
+    $path     = __DIR__ . '/../src/' . str_replace('\\', '/', $relative) . '.php';
+    if (is_file($path)) {
+        require $path;
+    }
+});
+
+use Example\CreateProduct;
+use Example\ProductRepo;
+use Rxn\Framework\App;
+use Rxn\Framework\Http\Binding\Binder;
+use Rxn\Framework\Http\Binding\ValidationException;
+use Rxn\Framework\Http\Health\HealthCheck;
+use Rxn\Framework\Http\Middleware\BearerAuth;
+use Rxn\Framework\Http\Middleware\RequestId;
+use Rxn\Framework\Http\Router;
+
+// In-memory storage. Static through `php -S`'s long-lived process.
+$repo = new ProductRepo();
+
+$router = new Router();
+
+// Health check — no auth, no DTO. The HealthCheck helper builds
+// the {data, meta} envelope; App::serve()'s arrayToPsrResponse
+// turns it into the right HTTP shape (200 on all-pass,
+// 503 + application/problem+json on any failure).
+HealthCheck::register($router, '/health', [
+    'repo' => fn (): bool => true, // pretend a real check
+]);
+
+// One BearerAuth middleware shared across the write routes. The
+// resolver maps a token string to a principal array (any shape;
+// commonly a user record). Returning null rejects the request
+// with a 401 Problem Details.
+$auth = new BearerAuth(
+    fn (string $token) => $token === 'demo' ? ['id' => 1, 'name' => 'Demo'] : null,
+);
+
+// Read routes. RequestId middleware injects an X-Request-Id
+// header on the response (and surfaces it via `RequestId::current()`
+// for downstream code).
+$router->get('/products', fn (): array => ['data' => $repo->all()])
+    ->middleware(new RequestId());
+
+$router->get('/products/{id:int}', function (array $params) use ($repo): array {
+    $product = $repo->find((int) $params['id']);
+    if ($product === null) {
+        return ['meta' => ['status' => 404, 'title' => 'Not Found']];
+    }
+    return ['data' => $product];
+})->middleware(new RequestId());
+
+// Write route — authenticated. Binder hydrates + validates the
+// DTO; ValidationException rolls up every failure into one 422
+// response (RFC 7807 Problem Details), no one-at-a-time loop.
+$router->post('/products', function (array $params, $request) use ($repo): array {
+    try {
+        $dto = Binder::bindRequest(CreateProduct::class, $request);
+    } catch (ValidationException $e) {
+        return ['meta' => [
+            'status' => 422,
+            'title'  => 'Unprocessable Entity',
+            'errors' => $e->errors(),
+        ]];
+    }
+    return ['data' => $repo->create($dto), 'meta' => ['status' => 201]];
+})->middleware($auth, new RequestId());
+
+App::serve($router);

--- a/examples/quickstart/src/CreateProduct.php
+++ b/examples/quickstart/src/CreateProduct.php
@@ -1,0 +1,36 @@
+<?php declare(strict_types=1);
+
+namespace Example;
+
+use Rxn\Framework\Http\Attribute\InSet;
+use Rxn\Framework\Http\Attribute\Length;
+use Rxn\Framework\Http\Attribute\Min;
+use Rxn\Framework\Http\Attribute\Required;
+use Rxn\Framework\Http\Binding\RequestDto;
+
+/**
+ * Wire-shape contract for `POST /products`. Public typed
+ * properties are populated by the Binder; attribute validation
+ * runs before the handler sees the instance.
+ *
+ * The same DTO is also read by:
+ *   - `Binder::compileFor()` — for the schema-compiled fast path
+ *   - `Http\OpenApi\Generator` — for the auto-generated spec
+ *   - the route conflict detector (`bin/rxn routes:check`)
+ *
+ * That's the framework's "schema as truth, multiple consumers"
+ * principle in 25 lines of PHP.
+ */
+final class CreateProduct implements RequestDto
+{
+    #[Required]
+    #[Length(min: 1, max: 100)]
+    public string $name;
+
+    #[Required]
+    #[Min(0)]
+    public int $price;
+
+    #[InSet(['draft', 'published', 'archived'])]
+    public string $status = 'draft';
+}

--- a/examples/quickstart/src/ProductRepo.php
+++ b/examples/quickstart/src/ProductRepo.php
@@ -12,6 +12,13 @@ namespace Example;
  * whatever storage they prefer. The point of this class is to
  * keep the quickstart self-contained — no MySQL, no SQLite, no
  * external setup.
+ *
+ * Concurrency: `create()` takes an exclusive `flock` on a sibling
+ * lock file across the whole load → modify → write cycle, so two
+ * php-fpm workers can't clobber each other's increments. The
+ * write itself is also atomic via temp + rename. Reads (`all()`,
+ * `find()`) are unlocked — they may briefly observe an
+ * almost-stale snapshot under contention but never a torn file.
  */
 final class ProductRepo
 {
@@ -34,17 +41,35 @@ final class ProductRepo
     /** @return array<string, mixed> */
     public function create(CreateProduct $dto): array
     {
-        $rows = $this->load();
-        $id   = $rows === [] ? 1 : (max(array_keys($rows)) + 1);
-        $row  = [
-            'id'     => $id,
-            'name'   => $dto->name,
-            'price'  => $dto->price,
-            'status' => $dto->status,
-        ];
-        $rows[$id] = $row;
-        $this->save($rows);
-        return $row;
+        $this->ensureDir();
+
+        // Lock the whole read-modify-write cycle so concurrent
+        // workers can't both compute id=N and produce two rows
+        // with the same id.
+        $lockPath = $this->path . '.lock';
+        $lockFh   = fopen($lockPath, 'c');
+        if ($lockFh === false) {
+            throw new \RuntimeException("ProductRepo: cannot open lock $lockPath");
+        }
+        try {
+            if (!flock($lockFh, LOCK_EX)) {
+                throw new \RuntimeException("ProductRepo: failed to acquire lock on $lockPath");
+            }
+            $rows = $this->load();
+            $id   = $rows === [] ? 1 : (max(array_keys($rows)) + 1);
+            $row  = [
+                'id'     => $id,
+                'name'   => $dto->name,
+                'price'  => $dto->price,
+                'status' => $dto->status,
+            ];
+            $rows[$id] = $row;
+            $this->save($rows);
+            return $row;
+        } finally {
+            flock($lockFh, LOCK_UN);
+            fclose($lockFh);
+        }
     }
 
     /** @return array<int, array<string, mixed>> */
@@ -53,25 +78,47 @@ final class ProductRepo
         if (!is_file($this->path)) {
             return [];
         }
-        $raw = file_get_contents($this->path);
+        $raw = @file_get_contents($this->path);
         if ($raw === false || $raw === '') {
             return [];
         }
-        $decoded = json_decode($raw, true);
+        try {
+            $decoded = json_decode($raw, true, flags: JSON_THROW_ON_ERROR);
+        } catch (\JsonException) {
+            // Corrupted store — treat as empty rather than crashing
+            // the request. Real apps would surface this; the
+            // quickstart prefers progress over alarms.
+            return [];
+        }
         return is_array($decoded) ? $decoded : [];
+    }
+
+    private function ensureDir(): void
+    {
+        $dir = dirname($this->path);
+        if (is_dir($dir)) {
+            return;
+        }
+        if (!mkdir($dir, 0775, true) && !is_dir($dir)) {
+            throw new \RuntimeException("ProductRepo: cannot create dir $dir");
+        }
     }
 
     /** @param array<int, array<string, mixed>> $rows */
     private function save(array $rows): void
     {
-        $dir = dirname($this->path);
-        if (!is_dir($dir)) {
-            mkdir($dir, 0775, true);
-        }
+        $json = json_encode($rows, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR);
+
         // Atomic via temp + rename so a concurrent reader never
         // sees a half-written file.
         $tmp = $this->path . '.' . bin2hex(random_bytes(4)) . '.tmp';
-        file_put_contents($tmp, json_encode($rows, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES));
-        rename($tmp, $this->path);
+        if (file_put_contents($tmp, $json) === false) {
+            @unlink($tmp);
+            throw new \RuntimeException("ProductRepo: failed to write $tmp");
+        }
+        if (!@rename($tmp, $this->path)) {
+            @unlink($tmp);
+            throw new \RuntimeException("ProductRepo: failed to rename $tmp -> $this->path");
+        }
     }
 }

--- a/examples/quickstart/src/ProductRepo.php
+++ b/examples/quickstart/src/ProductRepo.php
@@ -1,0 +1,77 @@
+<?php declare(strict_types=1);
+
+namespace Example;
+
+/**
+ * File-backed JSON store so the quickstart demonstrates real
+ * persistence across requests on the built-in `php -S` server
+ * (which reinitialises PHP state per request — instance state
+ * doesn't survive the boundary).
+ *
+ * Real apps swap this for an `rxn-orm`-backed implementation or
+ * whatever storage they prefer. The point of this class is to
+ * keep the quickstart self-contained — no MySQL, no SQLite, no
+ * external setup.
+ */
+final class ProductRepo
+{
+    public function __construct(
+        private readonly string $path = __DIR__ . '/../../../var/quickstart-products.json',
+    ) {}
+
+    /** @return list<array<string, mixed>> */
+    public function all(): array
+    {
+        return array_values($this->load());
+    }
+
+    /** @return array<string, mixed>|null */
+    public function find(int $id): ?array
+    {
+        return $this->load()[$id] ?? null;
+    }
+
+    /** @return array<string, mixed> */
+    public function create(CreateProduct $dto): array
+    {
+        $rows = $this->load();
+        $id   = $rows === [] ? 1 : (max(array_keys($rows)) + 1);
+        $row  = [
+            'id'     => $id,
+            'name'   => $dto->name,
+            'price'  => $dto->price,
+            'status' => $dto->status,
+        ];
+        $rows[$id] = $row;
+        $this->save($rows);
+        return $row;
+    }
+
+    /** @return array<int, array<string, mixed>> */
+    private function load(): array
+    {
+        if (!is_file($this->path)) {
+            return [];
+        }
+        $raw = file_get_contents($this->path);
+        if ($raw === false || $raw === '') {
+            return [];
+        }
+        $decoded = json_decode($raw, true);
+        return is_array($decoded) ? $decoded : [];
+    }
+
+    /** @param array<int, array<string, mixed>> $rows */
+    private function save(array $rows): void
+    {
+        $dir = dirname($this->path);
+        if (!is_dir($dir)) {
+            mkdir($dir, 0775, true);
+        }
+        // Atomic via temp + rename so a concurrent reader never
+        // sees a half-written file.
+        $tmp = $this->path . '.' . bin2hex(random_bytes(4)) . '.tmp';
+        file_put_contents($tmp, json_encode($rows, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES));
+        rename($tmp, $this->path);
+    }
+}

--- a/src/Rxn/Framework/Http/Health/HealthCheck.php
+++ b/src/Rxn/Framework/Http/Health/HealthCheck.php
@@ -52,7 +52,19 @@ final class HealthCheck
         string $path = '/health',
         array  $checks = [],
     ): \Rxn\Framework\Http\Route {
-        return $router->get($path, fn () => self::run($checks));
+        // Match the default invoker's `(params, request)` contract
+        // so the registered handler's signature documents what it
+        // actually accepts. Defaults on both params keep the
+        // closure invokable with zero args too — useful for tests
+        // that drive HealthCheck::run() through the registered
+        // handler without faking a request.
+        return $router->get(
+            $path,
+            static fn (
+                array $params = [],
+                ?\Psr\Http\Message\ServerRequestInterface $request = null,
+            ) => self::run($checks),
+        );
     }
 
     /**


### PR DESCRIPTION
## Summary

Closes the onboarding gap left by PR #65. The convention-router strip deleted the previous worked example (`examples/products-api/`), which depended on the deleted Service / Model / Data layer. This replacement demonstrates the modern shape end-to-end.

**Three files, 210 LOC. Live-tested against every route.**

## What it demonstrates

| Feature | Where |
|---|---|
| `App::serve(Router)` boot-free entry | `public/index.php`, last line |
| Pattern routing + typed constraints (`{id:int}`) | `/products/abc` → JSON 404, not HTML |
| Per-route middleware chain | `->middleware($auth, new RequestId())` |
| DTO binding + attribute validation | `Binder::bindRequest(CreateProduct::class, $request)` |
| Validation failure rolls up every error at once | `CreateProduct` with `Required`, `Length`, `Min`, `InSet` |
| RFC 7807 default | 401 / 404 / 422 all `application/problem+json` |
| HealthCheck helper | `HealthCheck::register()` |
| Schema as truth | `CreateProduct` drives binding, validation, AND `bin/rxn openapi --ns=Example --root=examples/quickstart` for the spec |
| File-backed persistence (no DB) | `ProductRepo` writes to `var/quickstart-products.json` (gitignored) |

## Run

\`\`\`bash
composer install
php -S 127.0.0.1:9871 -t examples/quickstart/public
\`\`\`

Then in another shell, exercise five paths covering health, list, authenticated create, validation failure, and auth failure. Full curl walkthrough in [`examples/quickstart/README.md`](examples/quickstart/README.md).

## Layout

\`\`\`
examples/quickstart/
├── README.md           ← walkthrough
├── public/index.php    ← 97 LOC entry, router, route registrations
└── src/
    ├── CreateProduct.php   ← 36 LOC DTO with validation attributes
    └── ProductRepo.php     ← 77 LOC file-backed JSON store
\`\`\`

## Test plan

- [x] \`vendor/bin/phpunit --testsuite=framework\` — 618 / 1329, no regressions
- [x] \`php -l\` clean across all three files
- [x] Live smoke-test under \`php -S\`:
  - GET /health → 200 with checks envelope
  - GET /products (empty) → 200 \`{"data":[]}\`
  - POST /products no auth → 401 Problem Details
  - POST /products with auth + valid DTO → 201 with stored row
  - POST /products with invalid DTO → 422 with errors[] for every failed field
  - GET /products → 200 with the persisted rows
  - GET /products/1 → 200 with the row
  - GET /products/abc → 404 Problem Details (typed constraint reject; NOT an HTML 404 from the SAPI)
- [x] State persists across requests via the JSON file