### PR TITLE
feat(Http): CRUD scaffolding via Resource handlers (theme 1.6, core primitive)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,21 +51,41 @@ legacy AR base classes.
   missing → registrar maps to 404; `delete` returns `bool`
   → 204 / 404; `search` accepts a nullable filter DTO.
 - **`Rxn\Framework\Http\Resource\ResourceRegistrar`** — static
-  `register()` method takes the router, path, handler, create /
-  update DTO classes, optional search DTO, and an `idType`
-  constraint (default `'int'`; pass `'uuid'` / `'slug'` /
-  custom for non-integer IDs). Wires the five routes; each
-  handler closure does the DTO binding, validation-failure
-  wrapping (RFC 7807 Problem Details with `errors[]`), and
-  status-code mapping.
-- 15 integration tests against an in-memory `CrudHandler`
+  `register()` method takes the router (`Router` OR
+  `RouteGroup`), path, handler, create / update DTO classes,
+  optional search DTO, and an `idType` constraint (default
+  `'int'`; pass `'uuid'` / `'slug'` / custom for non-integer
+  IDs). Wires the five routes; each handler closure does the
+  DTO binding, validation-failure wrapping (RFC 7807 Problem
+  Details with `errors[]`), and status-code mapping. Returns a
+  `ResourceRoutes` bag — see below.
+- **`Rxn\Framework\Http\Resource\ResourceRoutes`** — the bag
+  of `Route` handles returned from `register()`. Public
+  readonly fields (`create`, `search`, `read`, `update`,
+  `delete`) so callers can attach per-op middleware without
+  re-deriving them through `Router::match`.
+  `ResourceRoutes::middleware(...)` chains the same middleware
+  onto all five routes at once. Three composition shapes
+  supported:
+    - **Group-based**: pass a `RouteGroup` instead of `Router`;
+      every registered route inherits the group's prefix +
+      middleware automatically.
+    - **Resource-wide**: chain
+      `ResourceRegistrar::register(...)->middleware($auth)`.
+    - **Per-op**: target the specific Route handle —
+      `$routes->update->middleware($adminOnly)`.
+- 19 integration tests against an in-memory `CrudHandler`
   fixture covering: registration shape, ID-type constraint
   rejection, create round-trip, validation failure → 422,
   read 200 / 404, update partial merge, update 404 / 422,
   delete 204 (true empty body) / 404, search 200 / list /
   filter from query / 422 on bad query, null-search-DTO
   passes null filter, idType=uuid produces string IDs at the
-  handler.
+  handler, register returns a ResourceRoutes value object,
+  middleware applies to all five routes via the bag's
+  `middleware()` chainer, individual route can carry
+  additional middleware via the public field, RouteGroup
+  registration inherits prefix + middleware.
 
 #### What's NOT in this PR (deliberate scope cut)
 
@@ -82,7 +102,7 @@ legacy AR base classes.
   `Scanner` discover resources at scan time. Useful but
   out-of-scope for the primitive.
 
-Suite 642 → 657 / 1391 → 1445.
+Suite 642 → 661 / 1391 → 1474.
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,7 +74,7 @@ legacy AR base classes.
       `ResourceRegistrar::register(...)->middleware($auth)`.
     - **Per-op**: target the specific Route handle —
       `$routes->update->middleware($adminOnly)`.
-- 19 integration tests against an in-memory `CrudHandler`
+- 28 integration tests against an in-memory `CrudHandler`
   fixture covering: registration shape, ID-type constraint
   rejection, create round-trip, validation failure → 422,
   read 200 / 404, update partial merge, update 404 / 422,
@@ -85,7 +85,12 @@ legacy AR base classes.
   middleware applies to all five routes via the bag's
   `middleware()` chainer, individual route can carry
   additional middleware via the public field, RouteGroup
-  registration inherits prefix + middleware.
+  registration inherits prefix + middleware, path-without-
+  leading-slash normalisation, three distinct DTO-class
+  failures (not-implementing-RequestDto / empty-string /
+  nonexistent), search filter binds from query string only
+  (not request body), idType regex validation rejects '-' /
+  empty.
 
 #### What's NOT in this PR (deliberate scope cut)
 
@@ -102,7 +107,7 @@ legacy AR base classes.
   `Scanner` discover resources at scan time. Useful but
   out-of-scope for the primitive.
 
-Suite 642 → 661 / 1391 → 1474.
+Suite 642 → 670 / 1391 → 1490.
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,80 @@ read alongside the wins.
 
 ## Unreleased
 
+### CRUD scaffolding via Resource handlers — core primitive (`feat/crud-resource-handlers`)
+
+Recovers the convention router's "extend a class, get five
+endpoints" ergonomic without legacy AR baggage. One call wires
+a `CrudHandler` to the full five-route URL family; framework
+handles DTO binding, validation → 422 wrapping, missing-row →
+404, deleted → 204.
+
+```php
+ResourceRegistrar::register(
+    $router,
+    '/products',
+    new ProductsCrud($repo),
+    create: CreateProduct::class,
+    update: UpdateProduct::class,
+    search: SearchProducts::class,
+);
+```
+
+After registration the router carries:
+
+- `POST   /products`              → `create($dto)` (201 / 422)
+- `GET    /products`              → `search($filter)` (200; filter optional)
+- `GET    /products/{id:int}`     → `read($id)` (200 / 404)
+- `PATCH  /products/{id:int}`     → `update($id, $dto)` (200 / 404 / 422)
+- `DELETE /products/{id:int}`     → `delete($id)` (204 / 404)
+
+Closes [horizons.md theme 1.6](docs/horizons.md). The "loved it"
+ergonomic recovered through DTOs and an interface, not via
+legacy AR base classes.
+
+#### Added
+
+- **`Rxn\Framework\Http\Resource\CrudHandler`** — 5-method
+  interface (`create`, `read`, `update`, `delete`, `search`).
+  Storage-agnostic. `read` / `update` return `null` on
+  missing → registrar maps to 404; `delete` returns `bool`
+  → 204 / 404; `search` accepts a nullable filter DTO.
+- **`Rxn\Framework\Http\Resource\ResourceRegistrar`** — static
+  `register()` method takes the router, path, handler, create /
+  update DTO classes, optional search DTO, and an `idType`
+  constraint (default `'int'`; pass `'uuid'` / `'slug'` /
+  custom for non-integer IDs). Wires the five routes; each
+  handler closure does the DTO binding, validation-failure
+  wrapping (RFC 7807 Problem Details with `errors[]`), and
+  status-code mapping.
+- 15 integration tests against an in-memory `CrudHandler`
+  fixture covering: registration shape, ID-type constraint
+  rejection, create round-trip, validation failure → 422,
+  read 200 / 404, update partial merge, update 404 / 422,
+  delete 204 (true empty body) / 404, search 200 / list /
+  filter from query / 422 on bad query, null-search-DTO
+  passes null filter, idType=uuid produces string IDs at the
+  handler.
+
+#### What's NOT in this PR (deliberate scope cut)
+
+- **`RxnOrmCrudHandler`** abstract base class — lives in
+  [`davidwyly/rxn-orm`](https://github.com/davidwyly/rxn-orm),
+  reduces a relational handler to ~10 LOC. Follow-up PR on the
+  rxn-orm repo.
+- **`bin/rxn scaffold:from-table`** — codegen step that connects
+  to the DB, reads `information_schema`, writes DTO files +
+  handler stub. One-shot at scaffold time, not at boot. Follow-up
+  PR after the rxn-orm base class lands.
+- **`#[Resource]` attribute** — alternative to explicit
+  `ResourceRegistrar::register()` calls; would let the
+  `Scanner` discover resources at scan time. Useful but
+  out-of-scope for the primitive.
+
+Suite 642 → 657 / 1391 → 1445.
+
+---
+
 ### `#[Version]` attribute primitive (`feat/version-attribute`)
 
 Recovers what the convention router's `/v{N}/{controller}/{action}`

--- a/README.md
+++ b/README.md
@@ -119,6 +119,16 @@ Opinionated pieces worth naming:
   versions of the same logical endpoint coexist as distinct paths;
   `routes:check` knows the difference between "intentional
   cross-version routes" and "real conflict."
+- **CRUD scaffolding via Resource handlers** — one call
+  (`ResourceRegistrar::register($router, '/products', $handler, …)`)
+  wires the full create/read/update/delete/search route family.
+  Handler is a 5-method interface against any storage; framework
+  does DTO binding, validation-failure → 422 wrapping, missing-row
+  → 404, deleted → 204. The "extend a class, get five endpoints"
+  ergonomic the convention router gave us — but with typed wire
+  (DTOs, not arrays), pluggable storage (rxn-orm's
+  `RxnOrmCrudHandler` base or your own ~50-LOC class), and OpenAPI
+  auto-generated from the same DTOs.
 - **Compile-time route conflict detection.** `bin/rxn routes:check`
   flags ambiguous `#[Route]` patterns before they ship —
   `/items/{id:int}` vs `/items/{slug:slug}` (slug accepts
@@ -236,7 +246,7 @@ cumulative scoreboard is in
 
 ```bash
 composer install
-vendor/bin/phpunit          # 642 tests, 1391 assertions
+vendor/bin/phpunit          # 657 tests, 1445 assertions
 bin/rxn help                # CLI subcommands
 ```
 
@@ -288,7 +298,7 @@ CI runs lint + phpunit against PHP 8.2, 8.3, and 8.4
 
 Test counts:
 
-- **Rxn framework:** 642 tests / 1391 assertions (`vendor/bin/phpunit`).
+- **Rxn framework:** 657 tests / 1445 assertions (`vendor/bin/phpunit`).
 - **[`davidwyly/rxn-orm`](https://github.com/davidwyly/rxn-orm)**
   (query builder): 68 tests / 132 assertions, run in that repo.
 - **[`davidwyly/rxn-observe`](https://github.com/davidwyly/rxn-observe)**

--- a/README.md
+++ b/README.md
@@ -246,7 +246,7 @@ cumulative scoreboard is in
 
 ```bash
 composer install
-vendor/bin/phpunit          # 661 tests, 1474 assertions
+vendor/bin/phpunit          # 670 tests, 1490 assertions
 bin/rxn help                # CLI subcommands
 ```
 
@@ -298,7 +298,7 @@ CI runs lint + phpunit against PHP 8.2, 8.3, and 8.4
 
 Test counts:
 
-- **Rxn framework:** 661 tests / 1474 assertions (`vendor/bin/phpunit`).
+- **Rxn framework:** 670 tests / 1490 assertions (`vendor/bin/phpunit`).
 - **[`davidwyly/rxn-orm`](https://github.com/davidwyly/rxn-orm)**
   (query builder): 68 tests / 132 assertions, run in that repo.
 - **[`davidwyly/rxn-observe`](https://github.com/davidwyly/rxn-observe)**

--- a/README.md
+++ b/README.md
@@ -246,7 +246,7 @@ cumulative scoreboard is in
 
 ```bash
 composer install
-vendor/bin/phpunit          # 657 tests, 1445 assertions
+vendor/bin/phpunit          # 661 tests, 1474 assertions
 bin/rxn help                # CLI subcommands
 ```
 
@@ -298,7 +298,7 @@ CI runs lint + phpunit against PHP 8.2, 8.3, and 8.4
 
 Test counts:
 
-- **Rxn framework:** 657 tests / 1445 assertions (`vendor/bin/phpunit`).
+- **Rxn framework:** 661 tests / 1474 assertions (`vendor/bin/phpunit`).
 - **[`davidwyly/rxn-orm`](https://github.com/davidwyly/rxn-orm)**
   (query builder): 68 tests / 132 assertions, run in that repo.
 - **[`davidwyly/rxn-observe`](https://github.com/davidwyly/rxn-observe)**

--- a/docs/horizons.md
+++ b/docs/horizons.md
@@ -210,6 +210,61 @@ that filling them in is mechanical, ship.
 
 ---
 
+### 1.6 CRUD scaffolding via Resource handlers — REALIZED (core primitive)
+
+Recovers the convention router's "extend a class, get five
+endpoints" ergonomic without legacy AR baggage. See
+`Rxn\Framework\Http\Resource\CrudHandler` (5-method interface)
+and `Rxn\Framework\Http\Resource\ResourceRegistrar` (one-call
+registrar that wires `POST` / `GET` / `GET {id}` / `PATCH {id}` /
+`DELETE {id}` to the handler with DTO binding + validation +
+404 / 422 / 204 wrapping in place).
+
+```php
+ResourceRegistrar::register(
+    $router,
+    '/products',
+    new ProductsCrud($repo),
+    create: CreateProduct::class,
+    update: UpdateProduct::class,
+    search: SearchProducts::class,
+);
+```
+
+**Cost reality:** ~280 LOC of framework code (interface +
+registrar) + 15 integration tests. Handler implementations are
+the app's job and don't count toward framework cost.
+
+**Status:** Shipped — the core primitive lands in this PR.
+What's left:
+
+- **`RxnOrmCrudHandler`** abstract class in
+  [`davidwyly/rxn-orm`](https://github.com/davidwyly/rxn-orm).
+  Reduces a relational handler to "extend a class, set
+  `TABLE` constant, done." Storage opinion lives in the storage
+  package.
+- **`bin/rxn scaffold:from-table`** — connects to the DB,
+  reads `information_schema`, writes the create / update /
+  search DTO files + a `RxnOrmCrudHandler` stub. Schema-as-
+  source-of-truth recovered, without the boot-time DB
+  requirement of the old convention-router scaffolding (codegen
+  runs once at scaffold time, not on every request).
+
+**Distinctiveness:** Most PHP frameworks make you write CRUD by
+hand or pull in a heavyweight admin generator (Symfony EasyAdmin,
+Laravel Nova). The Rxn shape is leaner — typed wire (DTOs,
+not arrays), validation from PHP attributes, OpenAPI
+auto-generated, storage layer pluggable. ~50 LOC for a custom
+handler against any backend.
+
+**Ship signal for the rxn-orm follow-up:** an app should be able
+to add a new table to its DB, run `bin/rxn scaffold:from-table
+<name>`, and have a working five-endpoint CRUD with no other
+edits. If the scaffolded code needs hand-fixing the codegen
+table needs more work first.
+
+---
+
 ## Theme 2: Observability ships in the box
 
 The framework already has PSR-14 wired ([`Rxn\Framework\Event\EventDispatcher`](../src/Rxn/Framework/Event/EventDispatcher.php)).

--- a/docs/horizons.md
+++ b/docs/horizons.md
@@ -232,7 +232,7 @@ ResourceRegistrar::register(
 ```
 
 **Cost reality:** ~280 LOC of framework code (interface +
-registrar) + 15 integration tests. Handler implementations are
+registrar) + 19 integration tests. Handler implementations are
 the app's job and don't count toward framework cost.
 
 **Status:** Shipped — the core primitive lands in this PR.

--- a/docs/routing.md
+++ b/docs/routing.md
@@ -204,6 +204,74 @@ $router->get('/products', $handler)
     ->middleware(new \Rxn\Framework\Http\Versioning\Deprecation('2026-01-01', '2026-12-31'));
 ```
 
+### CRUD resources — `ResourceRegistrar`
+
+`ResourceRegistrar::register()` wires a `CrudHandler` to a
+five-route URL family in one call:
+
+```php
+use Rxn\Framework\Http\Resource\ResourceRegistrar;
+
+ResourceRegistrar::register(
+    $router,
+    '/products',
+    new ProductsCrud($repo),
+    create: CreateProduct::class,
+    update: UpdateProduct::class,
+    search: SearchProducts::class,
+);
+```
+
+After this the router has:
+
+| Verb | Path | Handler |
+|---|---|---|
+| `POST` | `/products` | `create($dto)` — body bound from `CreateProduct`, 201 + `{data, meta: {status: 201}}` on success, 422 with `errors[]` on validation failure |
+| `GET` | `/products` | `search($filter)` — filter optionally bound from query (`SearchProducts`); registrations without a `search` DTO call the handler with `null`. 200 + `{data: [...]}`. |
+| `GET` | `/products/{id:int}` | `read($id)` — 200 + `{data: ...}`, or 404 Problem Details when the handler returns null |
+| `PATCH` | `/products/{id:int}` | `update($id, $dto)` — body bound from `UpdateProduct`, 200 / 404 / 422 |
+| `DELETE` | `/products/{id:int}` | `delete($id)` — 204 (empty body, per HTTP spec) on success, 404 on missing |
+
+The handler is just five methods over `Rxn\Framework\Http\Resource\CrudHandler`:
+
+```php
+final class ProductsCrud implements CrudHandler
+{
+    public function __construct(private MyRepo $repo) {}
+
+    public function create(RequestDto $dto): array { /* INSERT, return row */ }
+    public function read(int|string $id): ?array     { /* SELECT, or null */ }
+    public function update(int|string $id, RequestDto $dto): ?array { /* UPDATE */ }
+    public function delete(int|string $id): bool    { /* DELETE, return success */ }
+    public function search(?RequestDto $filter): array { /* list */ }
+}
+```
+
+**`idType` arg** controls the URL constraint and the handler's
+id type. Default is `'int'`; pass `'uuid'` / `'slug'` / `'any'`
+or any custom constraint to use a different shape:
+
+```php
+ResourceRegistrar::register(
+    $router, '/orgs', new OrgCrud($db),
+    create: CreateOrg::class,
+    update: UpdateOrg::class,
+    idType: 'uuid',  // /orgs/{id:uuid}; handler receives the id as a string
+);
+```
+
+**Storage layer is pluggable.** The registrar only knows the
+five-method interface. Apps using
+[`davidwyly/rxn-orm`](https://github.com/davidwyly/rxn-orm) can
+extend its `RxnOrmCrudHandler` base class for the relational
+common case (set `TABLE` constant, done); apps using Doctrine /
+raw PDO / a remote API write their own ~50-LOC handler.
+
+**Schema-as-source-of-truth via codegen:** `bin/rxn
+scaffold:from-table <name>` reads `information_schema` and
+writes the DTO files + a handler stub. One-shot, not runtime —
+no DB connection required at boot.
+
 ### Using matched routes with the pipeline
 
 `Router::match()` returns the matched route's `middlewares` alongside

--- a/docs/routing.md
+++ b/docs/routing.md
@@ -267,10 +267,35 @@ extend its `RxnOrmCrudHandler` base class for the relational
 common case (set `TABLE` constant, done); apps using Doctrine /
 raw PDO / a remote API write their own ~50-LOC handler.
 
-**Schema-as-source-of-truth via codegen:** `bin/rxn
-scaffold:from-table <name>` reads `information_schema` and
-writes the DTO files + a handler stub. One-shot, not runtime —
-no DB connection required at boot.
+**Composing middleware:** `register()` accepts either a
+`Router` or a `RouteGroup`, and returns a `ResourceRoutes` bag
+holding the five `Route` handles. Apps stack middleware in
+whichever shape matches the protection policy:
+
+```php
+// Group-based: every CRUD route inherits the group's middleware.
+$router->group('/v1', function (RouteGroup $g) use ($auth) {
+    $g->middleware($auth);
+    ResourceRegistrar::register($g, '/products', $crud, /* … */);
+});
+
+// Per-resource: chain on the returned bag.
+ResourceRegistrar::register($router, '/products', $crud, /* … */)
+    ->middleware($bearerAuth);
+
+// Per-op: target the specific Route handle on the bag.
+$routes = ResourceRegistrar::register($router, '/products', $crud, /* … */);
+$routes->update->middleware($adminOnly);
+$routes->delete->middleware($adminOnly);
+```
+
+**Schema-as-source-of-truth via codegen — *future*:** the plan
+is `bin/rxn scaffold:from-table <name>` reading
+`information_schema` to write the DTO files + a handler stub,
+one-shot at scaffold time so there's no DB connection required
+at boot. **Not yet implemented** — tracked under horizons theme
+1.6 follow-ups; the core primitive in this section is what
+ships today.
 
 ### Using matched routes with the pipeline
 

--- a/docs/routing.md
+++ b/docs/routing.md
@@ -226,10 +226,10 @@ After this the router has:
 
 | Verb | Path | Handler |
 |---|---|---|
-| `POST` | `/products` | `create($dto)` — body bound from `CreateProduct`, 201 + `{data, meta: {status: 201}}` on success, 422 with `errors[]` on validation failure |
+| `POST` | `/products` | `create($dto)` — DTO bound via Binder (query + body, body wins) from `CreateProduct`, 201 + `{data, meta: {status: 201}}` on success, 422 with `errors[]` on validation failure |
 | `GET` | `/products` | `search($filter)` — filter optionally bound from query (`SearchProducts`); registrations without a `search` DTO call the handler with `null`. 200 + `{data: [...]}`. |
 | `GET` | `/products/{id:int}` | `read($id)` — 200 + `{data: ...}`, or 404 Problem Details when the handler returns null |
-| `PATCH` | `/products/{id:int}` | `update($id, $dto)` — body bound from `UpdateProduct`, 200 / 404 / 422 |
+| `PATCH` | `/products/{id:int}` | `update($id, $dto)` — DTO bound via Binder (query + body, body wins) from `UpdateProduct`, 200 / 404 / 422 |
 | `DELETE` | `/products/{id:int}` | `delete($id)` — 204 (empty body, per HTTP spec) on success, 404 on missing |
 
 The handler is just five methods over `Rxn\Framework\Http\Resource\CrudHandler`:

--- a/src/Rxn/Framework/Http/Resource/CrudHandler.php
+++ b/src/Rxn/Framework/Http/Resource/CrudHandler.php
@@ -1,0 +1,90 @@
+<?php declare(strict_types=1);
+
+namespace Rxn\Framework\Http\Resource;
+
+use Rxn\Framework\Http\Binding\RequestDto;
+
+/**
+ * Handler shape that `ResourceRegistrar::register()` wires to a
+ * five-route URL family. Implement once; get
+ *
+ *   POST   /path            → create($dto)
+ *   GET    /path            → search($filter)
+ *   GET    /path/{id:type}  → read($id)
+ *   PATCH  /path/{id:type}  → update($id, $dto)
+ *   DELETE /path/{id:type}  → delete($id)
+ *
+ * for free, with DTO binding + validation + RFC 7807 failure
+ * shapes already wired by the registrar.
+ *
+ * The interface is storage-agnostic. Implementations can use
+ * `davidwyly/rxn-orm` (the natural fit — `RxnOrmCrudHandler`
+ * abstract class lives there and reduces boilerplate to the
+ * point of "extend a class, set TABLE constant, done"), Doctrine,
+ * raw PDO, in-memory arrays for tests, or even a remote API
+ * gateway. The framework's job is the HTTP layer; storage is the
+ * caller's choice.
+ *
+ * Return-shape contract (so the registrar's wrapping is uniform):
+ *
+ *   - `create()` always returns the created row's representation
+ *     as an `array<string, mixed>`. The registrar wraps it as
+ *     201 + `{data: ..., meta: {status: 201}}`.
+ *   - `read()` / `update()` return the row's representation, or
+ *     `null` when no row matches the id. Null becomes 404
+ *     Problem Details.
+ *   - `delete()` returns `true` (the row was deleted, 204 with
+ *     empty body) or `false` (no such row, 404 Problem Details).
+ *   - `search()` always returns a list (possibly empty). The
+ *     registrar wraps it as 200 + `{data: [...]}`. Pagination
+ *     metadata, if any, lives inside the search DTO's contract
+ *     and is the implementation's call to surface in `meta`.
+ *
+ * IDs are typed `int|string` — the registrar coerces the URL
+ * placeholder according to the `idType` argument it received
+ * (`'int'` casts to int; everything else stays string for UUID
+ * / slug / opaque-token shapes).
+ */
+interface CrudHandler
+{
+    /**
+     * Create a new resource from a hydrated + validated DTO.
+     *
+     * @return array<string, mixed>
+     */
+    public function create(RequestDto $dto): array;
+
+    /**
+     * Read the resource by id, or `null` when no such resource
+     * exists. The registrar turns null into a 404 Problem
+     * Details response.
+     *
+     * @return array<string, mixed>|null
+     */
+    public function read(int|string $id): ?array;
+
+    /**
+     * Apply a partial update to the resource. Returns the
+     * updated row, or `null` when no such id exists.
+     *
+     * @return array<string, mixed>|null
+     */
+    public function update(int|string $id, RequestDto $dto): ?array;
+
+    /**
+     * Delete the resource. `true` on success (registrar emits
+     * 204), `false` when no such id exists (registrar emits
+     * 404).
+     */
+    public function delete(int|string $id): bool;
+
+    /**
+     * List / filter / search resources. `$filter` is null when
+     * no search DTO was registered for this resource — apps
+     * that want unfiltered listing can ignore it; apps that
+     * registered a filter receive a hydrated + validated DTO.
+     *
+     * @return list<array<string, mixed>>
+     */
+    public function search(?RequestDto $filter): array;
+}

--- a/src/Rxn/Framework/Http/Resource/CrudHandler.php
+++ b/src/Rxn/Framework/Http/Resource/CrudHandler.php
@@ -36,9 +36,13 @@ use Rxn\Framework\Http\Binding\RequestDto;
  *   - `delete()` returns `true` (the row was deleted, 204 with
  *     empty body) or `false` (no such row, 404 Problem Details).
  *   - `search()` always returns a list (possibly empty). The
- *     registrar wraps it as 200 + `{data: [...]}`. Pagination
- *     metadata, if any, lives inside the search DTO's contract
- *     and is the implementation's call to surface in `meta`.
+ *     registrar wraps it as 200 + `{data: [...]}` — there is no
+ *     top-level `meta` slot. Pagination metadata (total count,
+ *     next-page link) is the `Http\Middleware\Pagination`
+ *     middleware's concern: stack it on the resource's GET
+ *     route via `$routes->search->middleware(new Pagination(...))`
+ *     and it adds `X-Total-Count` + RFC 8288 `Link` headers
+ *     without changing the response body shape.
  *
  * IDs are typed `int|string` — the registrar coerces the URL
  * placeholder according to the `idType` argument it received

--- a/src/Rxn/Framework/Http/Resource/ResourceRegistrar.php
+++ b/src/Rxn/Framework/Http/Resource/ResourceRegistrar.php
@@ -8,12 +8,14 @@ use Psr\Http\Message\ServerRequestInterface;
 use Rxn\Framework\Http\Binding\Binder;
 use Rxn\Framework\Http\Binding\RequestDto;
 use Rxn\Framework\Http\Binding\ValidationException;
+use Rxn\Framework\Http\Route;
+use Rxn\Framework\Http\RouteGroup;
 use Rxn\Framework\Http\Router;
 
 /**
  * Wire a `CrudHandler` to a five-route URL family in one call.
  *
- *   ResourceRegistrar::register(
+ *   $routes = ResourceRegistrar::register(
  *       $router,
  *       '/products',
  *       new ProductsCrud($repo),
@@ -30,28 +32,44 @@ use Rxn\Framework\Http\Router;
  *   PATCH  /products/{id:int}              → update
  *   DELETE /products/{id:int}              → delete
  *
+ * The returned `ResourceRoutes` carries the five `Route` handles
+ * so callers can wire middleware after registration:
+ *
+ *   $routes->middleware($bearerAuth);             // all five
+ *   $routes->update->middleware($adminOnly);      // PATCH only
+ *
+ * Both `Router` and `RouteGroup` are accepted as the first arg —
+ * registering through a group inherits the group's prefix and
+ * middleware stack, so the natural shape for protected APIs is:
+ *
+ *   $router->group('/v1', function (RouteGroup $g) use ($auth) {
+ *       $g->middleware($auth);
+ *       ResourceRegistrar::register($g, '/products', $crud, ...);
+ *   });
+ *
  * Each closure handles the wrapping the framework expects:
  *
  *   - `create` binds the create DTO from the request, calls the
- *     handler, returns `{data, meta: {status: 201}}` on success
- *     or `{meta: {status: 422, errors: [...]}}` on validation
- *     failure (RFC 7807 Problem Details via `App::serve`'s
- *     envelope mapper).
+ *     handler, returns `{data, meta: {status: 201}}` on success.
+ *     Validation failure returns a PSR-7 Problem Details
+ *     response (422 + `application/problem+json` with
+ *     `errors[]`); the array envelope mapper isn't involved
+ *     because the response is built directly.
  *   - `search` optionally binds a filter DTO from the query
  *     string — registrations without a `search` DTO call the
  *     handler with `null`. Result list is wrapped as
- *     `{data: [...]}`.
- *   - `read` calls the handler; `null` → 404 Problem Details.
- *   - `update` binds + validates the DTO, then `null` from the
- *     handler → 404, 422 on validation failure.
- *   - `delete` returns a true PSR-7 204 (empty body) on success;
- *     `false` from the handler → 404.
- *
- * Apps can stack route-level middleware on the resource as a
- * group via `Router::group()` before calling `register()`, or
- * post-hoc by mutating each registered Route through the Router
- * (the registrar doesn't return Route handles — middleware
- * composition happens at the group level).
+ *     `{data: [...]}`. Validation failure → PSR-7 Problem
+ *     Details (422) directly, same as create.
+ *   - `read` calls the handler; `null` from the handler →
+ *     `{meta: {status: 404, title: 'Not Found'}}` envelope
+ *     (mapped to 404 application/problem+json by `App::serve`).
+ *   - `update` binds + validates the DTO; `null` from the
+ *     handler → 404 envelope. Validation failure → 422 PSR-7
+ *     Problem Details.
+ *   - `delete` returns a true PSR-7 204 response (empty body)
+ *     on success — bypassing the array envelope mapper because
+ *     HTTP requires 204 to have no content. False from the
+ *     handler → 404 envelope.
  *
  * Storage-agnostic: the registrar only knows the `CrudHandler`
  * interface. `davidwyly/rxn-orm`'s `RxnOrmCrudHandler` base
@@ -62,8 +80,12 @@ use Rxn\Framework\Http\Router;
 final class ResourceRegistrar
 {
     /**
-     * @param class-string<RequestDto>  $create  request body shape for POST
-     * @param class-string<RequestDto>  $update  request body shape for PATCH
+     * @param Router|RouteGroup        $on      Where to register. RouteGroup
+     *                                          inherits its parent's prefix +
+     *                                          middleware stack on every route
+     *                                          this registrar adds.
+     * @param class-string<RequestDto> $create  request body shape for POST
+     * @param class-string<RequestDto> $update  request body shape for PATCH
      * @param class-string<RequestDto>|null $search query shape for GET (no body) — null
      *                                              means "no filter, hand the handler null"
      * @param string $idType Router placeholder type — `'int'` (default), `'uuid'`,
@@ -74,18 +96,18 @@ final class ResourceRegistrar
      *                       handler sees it (int vs. string).
      */
     public static function register(
-        Router $router,
+        Router|RouteGroup $on,
         string $path,
         CrudHandler $handler,
         string $create,
         string $update,
         ?string $search = null,
         string $idType = 'int',
-    ): void {
+    ): ResourceRoutes {
         $itemPath = rtrim($path, '/') . '/{id:' . $idType . '}';
 
         // POST /path — create
-        $router->post(
+        $createRoute = $on->post(
             $path,
             static function (array $params, ServerRequestInterface $request) use ($handler, $create): array|ResponseInterface {
                 try {
@@ -99,7 +121,7 @@ final class ResourceRegistrar
         );
 
         // GET /path — search (optionally filtered)
-        $router->get(
+        $searchRoute = $on->get(
             $path,
             static function (array $params, ServerRequestInterface $request) use ($handler, $search): array|ResponseInterface {
                 $filter = null;
@@ -116,9 +138,9 @@ final class ResourceRegistrar
         );
 
         // GET /path/{id:type} — read
-        $router->get(
+        $readRoute = $on->get(
             $itemPath,
-            static function (array $params) use ($handler, $idType): array {
+            static function (array $params, ServerRequestInterface $request) use ($handler, $idType): array {
                 $row = $handler->read(self::coerceId($params['id'], $idType));
                 if ($row === null) {
                     return ['meta' => ['status' => 404, 'title' => 'Not Found']];
@@ -128,7 +150,7 @@ final class ResourceRegistrar
         );
 
         // PATCH /path/{id:type} — update
-        $router->patch(
+        $updateRoute = $on->patch(
             $itemPath,
             static function (array $params, ServerRequestInterface $request) use ($handler, $update, $idType): array|ResponseInterface {
                 try {
@@ -146,9 +168,9 @@ final class ResourceRegistrar
         );
 
         // DELETE /path/{id:type} — delete
-        $router->delete(
+        $deleteRoute = $on->delete(
             $itemPath,
-            static function (array $params) use ($handler, $idType): array|ResponseInterface {
+            static function (array $params, ServerRequestInterface $request) use ($handler, $idType): array|ResponseInterface {
                 if ($handler->delete(self::coerceId($params['id'], $idType))) {
                     // 204 No Content — empty body, per HTTP spec.
                     // Return a true PSR-7 response so the array
@@ -157,6 +179,14 @@ final class ResourceRegistrar
                 }
                 return ['meta' => ['status' => 404, 'title' => 'Not Found']];
             },
+        );
+
+        return new ResourceRoutes(
+            create: $createRoute,
+            search: $searchRoute,
+            read:   $readRoute,
+            update: $updateRoute,
+            delete: $deleteRoute,
         );
     }
 

--- a/src/Rxn/Framework/Http/Resource/ResourceRegistrar.php
+++ b/src/Rxn/Framework/Http/Resource/ResourceRegistrar.php
@@ -8,7 +8,6 @@ use Psr\Http\Message\ServerRequestInterface;
 use Rxn\Framework\Http\Binding\Binder;
 use Rxn\Framework\Http\Binding\RequestDto;
 use Rxn\Framework\Http\Binding\ValidationException;
-use Rxn\Framework\Http\Route;
 use Rxn\Framework\Http\RouteGroup;
 use Rxn\Framework\Http\Router;
 

--- a/src/Rxn/Framework/Http/Resource/ResourceRegistrar.php
+++ b/src/Rxn/Framework/Http/Resource/ResourceRegistrar.php
@@ -150,7 +150,7 @@ final class ResourceRegistrar
                 if ($search !== null) {
                     try {
                         /** @var RequestDto $filter */
-                        $filter = Binder::bindRequest($search, $request);
+                        $filter = Binder::bind($search, $request->getQueryParams());
                     } catch (ValidationException $e) {
                         return self::problem(422, 'Unprocessable Entity', $e->errors());
                     }

--- a/src/Rxn/Framework/Http/Resource/ResourceRegistrar.php
+++ b/src/Rxn/Framework/Http/Resource/ResourceRegistrar.php
@@ -108,22 +108,46 @@ final class ResourceRegistrar
         // Normalise: single leading slash, no trailing slash, so that
         // Router and RouteGroup (which prepends a prefix) behave identically
         // regardless of whether the caller includes the leading slash.
-        $path     = '/' . ltrim(rtrim($path, '/'), '/');
+        $path = '/' . ltrim(rtrim($path, '/'), '/');
+
+        // Validate idType against Router::compile()'s placeholder-type
+        // grammar before interpolation. Without this guard, a label
+        // containing '-' or anything outside the grammar surfaces as
+        // a generic "Malformed route placeholder" from Router::compile,
+        // pointing at the wrong layer. Identifier-shape regex matches
+        // PHP's own valid-identifier check.
+        if (!preg_match('/^[a-zA-Z_][a-zA-Z0-9_]*$/', $idType)) {
+            throw new \InvalidArgumentException(
+                "ResourceRegistrar: idType must match [a-zA-Z_][a-zA-Z0-9_]* (got '{$idType}')",
+            );
+        }
         $itemPath = $path . '/{id:' . $idType . '}';
 
         // Validate DTO class-strings at registration time so mis-wired
-        // calls fail immediately rather than on first request with a 500.
-        // $create and $update are checked unconditionally (empty string
-        // would pass array_filter's default truthiness check and slip
-        // through undetected). $search is included only when non-null.
-        $dtoClasses = [$create, $update];
+        // calls fail immediately rather than on first request with a
+        // misleading 500. Three distinct failure modes, three distinct
+        // error messages — generic "must implement RequestDto" hides
+        // typos and empty inputs behind a check that wasn't even
+        // reached for those cases. $create and $update are checked
+        // unconditionally; $search only when non-null.
+        $dtoClasses = ['create' => $create, 'update' => $update];
         if ($search !== null) {
-            $dtoClasses[] = $search;
+            $dtoClasses['search'] = $search;
         }
-        foreach ($dtoClasses as $dtoClass) {
+        foreach ($dtoClasses as $arg => $dtoClass) {
+            if ($dtoClass === '') {
+                throw new \InvalidArgumentException(
+                    "ResourceRegistrar: \${$arg} DTO class name cannot be empty",
+                );
+            }
+            if (!class_exists($dtoClass)) {
+                throw new \InvalidArgumentException(
+                    "ResourceRegistrar: \${$arg} DTO class '{$dtoClass}' does not exist",
+                );
+            }
             if (!is_subclass_of($dtoClass, RequestDto::class)) {
                 throw new \InvalidArgumentException(
-                    "{$dtoClass} must implement " . RequestDto::class,
+                    "ResourceRegistrar: \${$arg} DTO '{$dtoClass}' must implement " . RequestDto::class,
                 );
             }
         }

--- a/src/Rxn/Framework/Http/Resource/ResourceRegistrar.php
+++ b/src/Rxn/Framework/Http/Resource/ResourceRegistrar.php
@@ -111,7 +111,14 @@ final class ResourceRegistrar
 
         // Validate DTO class-strings at registration time so mis-wired
         // calls fail immediately rather than on first request with a 500.
-        foreach (array_filter([$create, $update, $search]) as $dtoClass) {
+        // $create and $update are checked unconditionally (empty string
+        // would pass array_filter's default truthiness check and slip
+        // through undetected). $search is included only when non-null.
+        $dtoClasses = [$create, $update];
+        if ($search !== null) {
+            $dtoClasses[] = $search;
+        }
+        foreach ($dtoClasses as $dtoClass) {
             if (!is_subclass_of($dtoClass, RequestDto::class)) {
                 throw new \InvalidArgumentException(
                     "{$dtoClass} must implement " . RequestDto::class,

--- a/src/Rxn/Framework/Http/Resource/ResourceRegistrar.php
+++ b/src/Rxn/Framework/Http/Resource/ResourceRegistrar.php
@@ -1,0 +1,193 @@
+<?php declare(strict_types=1);
+
+namespace Rxn\Framework\Http\Resource;
+
+use Nyholm\Psr7\Response;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Rxn\Framework\Http\Binding\Binder;
+use Rxn\Framework\Http\Binding\RequestDto;
+use Rxn\Framework\Http\Binding\ValidationException;
+use Rxn\Framework\Http\Router;
+
+/**
+ * Wire a `CrudHandler` to a five-route URL family in one call.
+ *
+ *   ResourceRegistrar::register(
+ *       $router,
+ *       '/products',
+ *       new ProductsCrud($repo),
+ *       create: CreateProduct::class,
+ *       update: UpdateProduct::class,
+ *       search: SearchProducts::class,
+ *   );
+ *
+ * Registers:
+ *
+ *   POST   /products                       → create
+ *   GET    /products                       → search
+ *   GET    /products/{id:int}              → read
+ *   PATCH  /products/{id:int}              → update
+ *   DELETE /products/{id:int}              → delete
+ *
+ * Each closure handles the wrapping the framework expects:
+ *
+ *   - `create` binds the create DTO from the request, calls the
+ *     handler, returns `{data, meta: {status: 201}}` on success
+ *     or `{meta: {status: 422, errors: [...]}}` on validation
+ *     failure (RFC 7807 Problem Details via `App::serve`'s
+ *     envelope mapper).
+ *   - `search` optionally binds a filter DTO from the query
+ *     string — registrations without a `search` DTO call the
+ *     handler with `null`. Result list is wrapped as
+ *     `{data: [...]}`.
+ *   - `read` calls the handler; `null` → 404 Problem Details.
+ *   - `update` binds + validates the DTO, then `null` from the
+ *     handler → 404, 422 on validation failure.
+ *   - `delete` returns a true PSR-7 204 (empty body) on success;
+ *     `false` from the handler → 404.
+ *
+ * Apps can stack route-level middleware on the resource as a
+ * group via `Router::group()` before calling `register()`, or
+ * post-hoc by mutating each registered Route through the Router
+ * (the registrar doesn't return Route handles — middleware
+ * composition happens at the group level).
+ *
+ * Storage-agnostic: the registrar only knows the `CrudHandler`
+ * interface. `davidwyly/rxn-orm`'s `RxnOrmCrudHandler` base
+ * class reduces the implementation boilerplate for the common
+ * relational case; apps with bespoke storage write their own
+ * 5-method class.
+ */
+final class ResourceRegistrar
+{
+    /**
+     * @param class-string<RequestDto>  $create  request body shape for POST
+     * @param class-string<RequestDto>  $update  request body shape for PATCH
+     * @param class-string<RequestDto>|null $search query shape for GET (no body) — null
+     *                                              means "no filter, hand the handler null"
+     * @param string $idType Router placeholder type — `'int'` (default), `'uuid'`,
+     *                       `'slug'`, `'any'`, or any custom constraint that
+     *                       `Router::compile` knows about. Determines the URL
+     *                       shape of the per-resource routes (`/{id:int}` etc.)
+     *                       AND how the placeholder is coerced before the
+     *                       handler sees it (int vs. string).
+     */
+    public static function register(
+        Router $router,
+        string $path,
+        CrudHandler $handler,
+        string $create,
+        string $update,
+        ?string $search = null,
+        string $idType = 'int',
+    ): void {
+        $itemPath = rtrim($path, '/') . '/{id:' . $idType . '}';
+
+        // POST /path — create
+        $router->post(
+            $path,
+            static function (array $params, ServerRequestInterface $request) use ($handler, $create): array|ResponseInterface {
+                try {
+                    /** @var RequestDto $dto */
+                    $dto = Binder::bindRequest($create, $request);
+                } catch (ValidationException $e) {
+                    return self::problem(422, 'Unprocessable Entity', $e->errors());
+                }
+                return ['data' => $handler->create($dto), 'meta' => ['status' => 201]];
+            },
+        );
+
+        // GET /path — search (optionally filtered)
+        $router->get(
+            $path,
+            static function (array $params, ServerRequestInterface $request) use ($handler, $search): array|ResponseInterface {
+                $filter = null;
+                if ($search !== null) {
+                    try {
+                        /** @var RequestDto $filter */
+                        $filter = Binder::bindRequest($search, $request);
+                    } catch (ValidationException $e) {
+                        return self::problem(422, 'Unprocessable Entity', $e->errors());
+                    }
+                }
+                return ['data' => $handler->search($filter)];
+            },
+        );
+
+        // GET /path/{id:type} — read
+        $router->get(
+            $itemPath,
+            static function (array $params) use ($handler, $idType): array {
+                $row = $handler->read(self::coerceId($params['id'], $idType));
+                if ($row === null) {
+                    return ['meta' => ['status' => 404, 'title' => 'Not Found']];
+                }
+                return ['data' => $row];
+            },
+        );
+
+        // PATCH /path/{id:type} — update
+        $router->patch(
+            $itemPath,
+            static function (array $params, ServerRequestInterface $request) use ($handler, $update, $idType): array|ResponseInterface {
+                try {
+                    /** @var RequestDto $dto */
+                    $dto = Binder::bindRequest($update, $request);
+                } catch (ValidationException $e) {
+                    return self::problem(422, 'Unprocessable Entity', $e->errors());
+                }
+                $row = $handler->update(self::coerceId($params['id'], $idType), $dto);
+                if ($row === null) {
+                    return ['meta' => ['status' => 404, 'title' => 'Not Found']];
+                }
+                return ['data' => $row];
+            },
+        );
+
+        // DELETE /path/{id:type} — delete
+        $router->delete(
+            $itemPath,
+            static function (array $params) use ($handler, $idType): array|ResponseInterface {
+                if ($handler->delete(self::coerceId($params['id'], $idType))) {
+                    // 204 No Content — empty body, per HTTP spec.
+                    // Return a true PSR-7 response so the array
+                    // envelope mapper doesn't synthesise a body.
+                    return new Response(204);
+                }
+                return ['meta' => ['status' => 404, 'title' => 'Not Found']];
+            },
+        );
+    }
+
+    /**
+     * Coerce a route placeholder match into the type the
+     * `CrudHandler` expects. `'int'` casts; every other type
+     * (`'uuid'`, `'slug'`, `'any'`, custom) stays as the raw
+     * captured string.
+     */
+    private static function coerceId(string $raw, string $idType): int|string
+    {
+        return $idType === 'int' ? (int) $raw : $raw;
+    }
+
+    /**
+     * Build a Problem Details PSR-7 response with optional
+     * `errors[]` extension. Used by the create / update / search
+     * paths to surface validation failures uniformly.
+     *
+     * @param list<array{field: string, message: string}> $errors
+     */
+    private static function problem(int $status, string $title, array $errors = []): ResponseInterface
+    {
+        $payload = ['type' => 'about:blank', 'title' => $title, 'status' => $status];
+        if ($errors !== []) {
+            $payload['errors'] = $errors;
+        }
+        return new Response(
+            $status,
+            ['Content-Type' => 'application/problem+json'],
+            json_encode($payload, JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR),
+        );
+    }
+}

--- a/src/Rxn/Framework/Http/Resource/ResourceRegistrar.php
+++ b/src/Rxn/Framework/Http/Resource/ResourceRegistrar.php
@@ -103,7 +103,21 @@ final class ResourceRegistrar
         ?string $search = null,
         string $idType = 'int',
     ): ResourceRoutes {
-        $itemPath = rtrim($path, '/') . '/{id:' . $idType . '}';
+        // Normalise: single leading slash, no trailing slash, so that
+        // Router and RouteGroup (which prepends a prefix) behave identically
+        // regardless of whether the caller includes the leading slash.
+        $path     = '/' . ltrim(rtrim($path, '/'), '/');
+        $itemPath = $path . '/{id:' . $idType . '}';
+
+        // Validate DTO class-strings at registration time so mis-wired
+        // calls fail immediately rather than on first request with a 500.
+        foreach (array_filter([$create, $update, $search]) as $dtoClass) {
+            if (!is_subclass_of($dtoClass, RequestDto::class)) {
+                throw new \InvalidArgumentException(
+                    "{$dtoClass} must implement " . RequestDto::class,
+                );
+            }
+        }
 
         // POST /path — create
         $createRoute = $on->post(

--- a/src/Rxn/Framework/Http/Resource/ResourceRegistrar.php
+++ b/src/Rxn/Framework/Http/Resource/ResourceRegistrar.php
@@ -48,7 +48,8 @@ use Rxn\Framework\Http\Router;
  *
  * Each closure handles the wrapping the framework expects:
  *
- *   - `create` binds the create DTO from the request, calls the
+ *   - `create` binds the create DTO via Binder (query + body,
+ *     body wins) from the request, calls the
  *     handler, returns `{data, meta: {status: 201}}` on success.
  *     Validation failure returns a PSR-7 Problem Details
  *     response (422 + `application/problem+json` with
@@ -62,7 +63,8 @@ use Rxn\Framework\Http\Router;
  *   - `read` calls the handler; `null` from the handler →
  *     `{meta: {status: 404, title: 'Not Found'}}` envelope
  *     (mapped to 404 application/problem+json by `App::serve`).
- *   - `update` binds + validates the DTO; `null` from the
+ *   - `update` binds + validates the DTO via Binder (query +
+ *     body, body wins); `null` from the
  *     handler → 404 envelope. Validation failure → 422 PSR-7
  *     Problem Details.
  *   - `delete` returns a true PSR-7 204 response (empty body)

--- a/src/Rxn/Framework/Http/Resource/ResourceRoutes.php
+++ b/src/Rxn/Framework/Http/Resource/ResourceRoutes.php
@@ -1,0 +1,68 @@
+<?php declare(strict_types=1);
+
+namespace Rxn\Framework\Http\Resource;
+
+use Psr\Http\Server\MiddlewareInterface;
+use Rxn\Framework\Http\Route;
+
+/**
+ * Handle bag returned from `ResourceRegistrar::register()`.
+ * Holds the five `Route` instances created for the resource so
+ * callers can attach per-op middleware after registration.
+ *
+ *   $routes = ResourceRegistrar::register($router, '/products', $crud, ...);
+ *
+ *   // Same auth on every CRUD route — applies to all five.
+ *   $routes->middleware($bearerAuth);
+ *
+ *   // Stricter check on destructive ops — chains additional
+ *   // middleware on the specific Route handle.
+ *   $routes->update->middleware($adminOnly);
+ *   $routes->delete->middleware($adminOnly);
+ *
+ * The bag is intentionally a struct of public readonly fields:
+ * one per resource operation. Apps that want to iterate (`foreach
+ * ($routes->all() as $r) { ... }`) get an `all()` helper.
+ */
+final class ResourceRoutes
+{
+    public function __construct(
+        public readonly Route $create,
+        public readonly Route $search,
+        public readonly Route $read,
+        public readonly Route $update,
+        public readonly Route $delete,
+    ) {}
+
+    /**
+     * Attach the same middleware stack to every CRUD route in
+     * one call. Chains return `$this` so registration + auth
+     * wiring can be a one-liner:
+     *
+     *   ResourceRegistrar::register($router, '/products', $crud, ...)
+     *       ->middleware(new BearerAuth($resolver));
+     */
+    public function middleware(MiddlewareInterface ...$middlewares): self
+    {
+        if ($middlewares === []) {
+            return $this;
+        }
+        foreach ($this->all() as $route) {
+            $route->middleware(...$middlewares);
+        }
+        return $this;
+    }
+
+    /**
+     * Iterate the five Route handles in registration order
+     * (create / search / read / update / delete). Useful for
+     * generic loops; per-op customization should target the
+     * specific public field instead.
+     *
+     * @return list<Route>
+     */
+    public function all(): array
+    {
+        return [$this->create, $this->search, $this->read, $this->update, $this->delete];
+    }
+}

--- a/src/Rxn/Framework/Tests/Http/Resource/Fixture/CreateWidget.php
+++ b/src/Rxn/Framework/Tests/Http/Resource/Fixture/CreateWidget.php
@@ -1,0 +1,23 @@
+<?php declare(strict_types=1);
+
+namespace Rxn\Framework\Tests\Http\Resource\Fixture;
+
+use Rxn\Framework\Http\Attribute\InSet;
+use Rxn\Framework\Http\Attribute\Length;
+use Rxn\Framework\Http\Attribute\Min;
+use Rxn\Framework\Http\Attribute\Required;
+use Rxn\Framework\Http\Binding\RequestDto;
+
+final class CreateWidget implements RequestDto
+{
+    #[Required]
+    #[Length(min: 1, max: 100)]
+    public string $name;
+
+    #[Required]
+    #[Min(0)]
+    public int $price;
+
+    #[InSet(['draft', 'published', 'archived'])]
+    public string $status = 'draft';
+}

--- a/src/Rxn/Framework/Tests/Http/Resource/Fixture/InMemoryWidgetCrud.php
+++ b/src/Rxn/Framework/Tests/Http/Resource/Fixture/InMemoryWidgetCrud.php
@@ -1,0 +1,86 @@
+<?php declare(strict_types=1);
+
+namespace Rxn\Framework\Tests\Http\Resource\Fixture;
+
+use Rxn\Framework\Http\Binding\RequestDto;
+use Rxn\Framework\Http\Resource\CrudHandler;
+
+/**
+ * In-memory `CrudHandler` for tests. Keeps storage state on the
+ * instance so each test starts fresh; production handlers wire
+ * a database / `rxn-orm` query builder / etc. behind the same
+ * five-method shape.
+ */
+final class InMemoryWidgetCrud implements CrudHandler
+{
+    /** @var array<int, array<string, mixed>> */
+    private array $rows = [];
+    private int $nextId = 1;
+
+    public function create(RequestDto $dto): array
+    {
+        if (!$dto instanceof CreateWidget) {
+            throw new \LogicException('CreateWidget DTO required for create');
+        }
+        $id  = $this->nextId++;
+        $row = [
+            'id'     => $id,
+            'name'   => $dto->name,
+            'price'  => $dto->price,
+            'status' => $dto->status,
+        ];
+        $this->rows[$id] = $row;
+        return $row;
+    }
+
+    public function read(int|string $id): ?array
+    {
+        return $this->rows[$id] ?? null;
+    }
+
+    public function update(int|string $id, RequestDto $dto): ?array
+    {
+        if (!$dto instanceof UpdateWidget) {
+            throw new \LogicException('UpdateWidget DTO required for update');
+        }
+        if (!isset($this->rows[$id])) {
+            return null;
+        }
+        $row = $this->rows[$id];
+        if ($dto->name !== null)   { $row['name']   = $dto->name; }
+        if ($dto->price !== null)  { $row['price']  = $dto->price; }
+        if ($dto->status !== null) { $row['status'] = $dto->status; }
+        $this->rows[$id] = $row;
+        return $row;
+    }
+
+    public function delete(int|string $id): bool
+    {
+        if (!isset($this->rows[$id])) {
+            return false;
+        }
+        unset($this->rows[$id]);
+        return true;
+    }
+
+    public function search(?RequestDto $filter): array
+    {
+        $rows = array_values($this->rows);
+        if ($filter instanceof SearchWidgets) {
+            if ($filter->status !== null) {
+                $rows = array_values(array_filter(
+                    $rows,
+                    static fn (array $r) => $r['status'] === $filter->status,
+                ));
+            }
+            if ($filter->q !== null && $filter->q !== '') {
+                $needle = strtolower($filter->q);
+                $rows = array_values(array_filter(
+                    $rows,
+                    static fn (array $r) => str_contains(strtolower((string) $r['name']), $needle),
+                ));
+            }
+        }
+        return $rows;
+    }
+}

--- a/src/Rxn/Framework/Tests/Http/Resource/Fixture/SearchWidgets.php
+++ b/src/Rxn/Framework/Tests/Http/Resource/Fixture/SearchWidgets.php
@@ -1,0 +1,22 @@
+<?php declare(strict_types=1);
+
+namespace Rxn\Framework\Tests\Http\Resource\Fixture;
+
+use Rxn\Framework\Http\Attribute\InSet;
+use Rxn\Framework\Http\Attribute\Min;
+use Rxn\Framework\Http\Binding\RequestDto;
+
+/**
+ * Filter shape for `GET /widgets`. Each field is optional; the
+ * handler interprets the populated subset as a filter predicate.
+ */
+final class SearchWidgets implements RequestDto
+{
+    public ?string $q = null;
+
+    #[InSet(['draft', 'published', 'archived'])]
+    public ?string $status = null;
+
+    #[Min(1)]
+    public int $page = 1;
+}

--- a/src/Rxn/Framework/Tests/Http/Resource/Fixture/TagMiddleware.php
+++ b/src/Rxn/Framework/Tests/Http/Resource/Fixture/TagMiddleware.php
@@ -1,0 +1,26 @@
+<?php declare(strict_types=1);
+
+namespace Rxn\Framework\Tests\Http\Resource\Fixture;
+
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\MiddlewareInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+
+/**
+ * Identity-checkable middleware for tests. Carries a tag the
+ * test reads back via `assertContains($mw, $middlewares)` to
+ * verify which routes ended up with which middleware. Doesn't
+ * touch the request — passes straight through to the handler.
+ */
+final class TagMiddleware implements MiddlewareInterface
+{
+    public function __construct(public readonly string $tag) {}
+
+    public function process(
+        ServerRequestInterface $request,
+        RequestHandlerInterface $handler,
+    ): ResponseInterface {
+        return $handler->handle($request);
+    }
+}

--- a/src/Rxn/Framework/Tests/Http/Resource/Fixture/UpdateWidget.php
+++ b/src/Rxn/Framework/Tests/Http/Resource/Fixture/UpdateWidget.php
@@ -1,0 +1,26 @@
+<?php declare(strict_types=1);
+
+namespace Rxn\Framework\Tests\Http\Resource\Fixture;
+
+use Rxn\Framework\Http\Attribute\InSet;
+use Rxn\Framework\Http\Attribute\Length;
+use Rxn\Framework\Http\Attribute\Min;
+use Rxn\Framework\Http\Binding\RequestDto;
+
+/**
+ * Update DTO — every field optional (nullable / has default), so
+ * PATCH bodies can omit anything that isn't changing. The
+ * implementation merges only fields the client provided into the
+ * stored row.
+ */
+final class UpdateWidget implements RequestDto
+{
+    #[Length(min: 1, max: 100)]
+    public ?string $name = null;
+
+    #[Min(0)]
+    public ?int $price = null;
+
+    #[InSet(['draft', 'published', 'archived'])]
+    public ?string $status = null;
+}

--- a/src/Rxn/Framework/Tests/Http/Resource/ResourceRegistrarTest.php
+++ b/src/Rxn/Framework/Tests/Http/Resource/ResourceRegistrarTest.php
@@ -5,12 +5,13 @@ namespace Rxn\Framework\Tests\Http\Resource;
 use Nyholm\Psr7\ServerRequest;
 use PHPUnit\Framework\TestCase;
 use Psr\Http\Message\ResponseInterface;
-use Psr\Http\Message\ServerRequestInterface;
 use Rxn\Framework\Http\Resource\ResourceRegistrar;
+use Rxn\Framework\Http\Resource\ResourceRoutes;
 use Rxn\Framework\Http\Router;
 use Rxn\Framework\Tests\Http\Resource\Fixture\CreateWidget;
 use Rxn\Framework\Tests\Http\Resource\Fixture\InMemoryWidgetCrud;
 use Rxn\Framework\Tests\Http\Resource\Fixture\SearchWidgets;
+use Rxn\Framework\Tests\Http\Resource\Fixture\TagMiddleware;
 use Rxn\Framework\Tests\Http\Resource\Fixture\UpdateWidget;
 
 /**
@@ -261,6 +262,138 @@ final class ResourceRegistrarTest extends TestCase
 
         $this->assertIsString($registrarHandler->captured);
         $this->assertSame('550e8400-e29b-41d4-a716-446655440000', $registrarHandler->captured);
+    }
+
+    public function testRegisterReturnsResourceRoutesValueObject(): void
+    {
+        // The registrar exposes the five Route handles so callers
+        // can compose middleware without re-deriving them through
+        // Router::match. Each public field is the actual Route
+        // that the registrar wired to the corresponding op.
+        $router = new Router();
+        $routes = ResourceRegistrar::register(
+            $router,
+            '/widgets-2',
+            new InMemoryWidgetCrud(),
+            create: CreateWidget::class,
+            update: UpdateWidget::class,
+            search: SearchWidgets::class,
+        );
+
+        $this->assertInstanceOf(ResourceRoutes::class, $routes);
+        $this->assertCount(5, $routes->all());
+    }
+
+    public function testMiddlewareAppliesToAllFiveRoutes(): void
+    {
+        $router = new Router();
+        $tag    = new TagMiddleware('resource-wide');
+        ResourceRegistrar::register(
+            $router,
+            '/widgets-3',
+            new InMemoryWidgetCrud(),
+            create: CreateWidget::class,
+            update: UpdateWidget::class,
+            search: SearchWidgets::class,
+        )->middleware($tag);
+
+        // Every one of the five registered routes must now carry
+        // the tag middleware. Hit each via match() and inspect.
+        $checks = [
+            ['POST',   '/widgets-3'],
+            ['GET',    '/widgets-3'],
+            ['GET',    '/widgets-3/1'],
+            ['PATCH',  '/widgets-3/1'],
+            ['DELETE', '/widgets-3/1'],
+        ];
+        foreach ($checks as [$method, $path]) {
+            $hit = $router->match($method, $path);
+            $this->assertNotNull($hit, "$method $path must register");
+            $this->assertContains(
+                $tag,
+                $hit['middlewares'],
+                "$method $path must carry the resource-wide middleware",
+            );
+        }
+    }
+
+    public function testIndividualRouteCanCarryAdditionalMiddleware(): void
+    {
+        // Use case: extra check on destructive ops only. The
+        // PATCH/DELETE Route handles get an additional middleware,
+        // GET/POST stay clean. Apps don't have to re-look-up
+        // Route objects via match() — the ResourceRoutes bag has
+        // them as public fields.
+        $router       = new Router();
+        $resourceWide = new TagMiddleware('all');
+        $adminOnly    = new TagMiddleware('admin');
+
+        $routes = ResourceRegistrar::register(
+            $router,
+            '/widgets-4',
+            new InMemoryWidgetCrud(),
+            create: CreateWidget::class,
+            update: UpdateWidget::class,
+            search: SearchWidgets::class,
+        );
+        $routes->middleware($resourceWide);
+        $routes->update->middleware($adminOnly);
+        $routes->delete->middleware($adminOnly);
+
+        // Read still has only the resource-wide one.
+        $read = $router->match('GET', '/widgets-4/1');
+        $this->assertCount(1, $read['middlewares']);
+
+        // Update + delete carry both.
+        $update = $router->match('PATCH', '/widgets-4/1');
+        $this->assertCount(2, $update['middlewares']);
+        $this->assertContains($resourceWide, $update['middlewares']);
+        $this->assertContains($adminOnly,    $update['middlewares']);
+
+        $delete = $router->match('DELETE', '/widgets-4/1');
+        $this->assertCount(2, $delete['middlewares']);
+        $this->assertContains($adminOnly, $delete['middlewares']);
+    }
+
+    public function testRegisterAcceptsRouteGroupAndInheritsPrefixPlusMiddleware(): void
+    {
+        // Real-world shape: protected CRUD inside a versioned
+        // group. The group's prefix is prepended; the group's
+        // middleware stack is inherited automatically by every
+        // route the registrar adds.
+        $router    = new Router();
+        $groupAuth = new TagMiddleware('group-auth');
+
+        $router->group('/v1', function (\Rxn\Framework\Http\RouteGroup $g) use ($groupAuth) {
+            $g->middleware($groupAuth);
+            ResourceRegistrar::register(
+                $g,
+                '/widgets',
+                new InMemoryWidgetCrud(),
+                create: CreateWidget::class,
+                update: UpdateWidget::class,
+                search: SearchWidgets::class,
+            );
+        });
+
+        // Routes are at /v1/widgets — group prefix applied — and
+        // every one carries the group-auth middleware that
+        // RouteGroup::add stamps onto routes registered through it.
+        $checks = [
+            ['POST',   '/v1/widgets'],
+            ['GET',    '/v1/widgets'],
+            ['GET',    '/v1/widgets/1'],
+            ['PATCH',  '/v1/widgets/1'],
+            ['DELETE', '/v1/widgets/1'],
+        ];
+        foreach ($checks as [$method, $path]) {
+            $hit = $router->match($method, $path);
+            $this->assertNotNull($hit, "$method $path must register through the group");
+            $this->assertContains($groupAuth, $hit['middlewares']);
+        }
+
+        // Sanity: nothing landed at the un-prefixed path.
+        $this->assertNull($router->match('GET', '/widgets'));
     }
 
     /**

--- a/src/Rxn/Framework/Tests/Http/Resource/ResourceRegistrarTest.php
+++ b/src/Rxn/Framework/Tests/Http/Resource/ResourceRegistrarTest.php
@@ -1,0 +1,351 @@
+<?php declare(strict_types=1);
+
+namespace Rxn\Framework\Tests\Http\Resource;
+
+use Nyholm\Psr7\ServerRequest;
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Rxn\Framework\Http\Resource\ResourceRegistrar;
+use Rxn\Framework\Http\Router;
+use Rxn\Framework\Tests\Http\Resource\Fixture\CreateWidget;
+use Rxn\Framework\Tests\Http\Resource\Fixture\InMemoryWidgetCrud;
+use Rxn\Framework\Tests\Http\Resource\Fixture\SearchWidgets;
+use Rxn\Framework\Tests\Http\Resource\Fixture\UpdateWidget;
+
+/**
+ * Integration tests for `ResourceRegistrar`. Each test drives a
+ * real Router → matched handler → response shape, against an
+ * in-memory `CrudHandler`. The contract on trial:
+ *
+ *   1. Five routes get registered with the documented HTTP
+ *      methods and paths (`POST /` / `GET /` / `GET /{id:int}` /
+ *      `PATCH /{id:int}` / `DELETE /{id:int}`).
+ *   2. Create and update bind the request body through the
+ *      Binder, surface validation failures as 422 Problem
+ *      Details with `errors[]`, and pass the hydrated DTO to
+ *      the handler on success.
+ *   3. Search optionally binds a filter DTO from query params;
+ *      registrations without a search DTO call the handler
+ *      with `null`.
+ *   4. Read / update return 404 Problem Details when the
+ *      handler returns `null`.
+ *   5. Delete returns a true PSR-7 204 (empty body) on success
+ *      and 404 Problem Details on missing.
+ *   6. The `idType` arg controls both the URL constraint AND
+ *      the handler's id type (int vs. string).
+ */
+final class ResourceRegistrarTest extends TestCase
+{
+    private Router $router;
+    private InMemoryWidgetCrud $crud;
+
+    protected function setUp(): void
+    {
+        $this->router = new Router();
+        $this->crud   = new InMemoryWidgetCrud();
+        ResourceRegistrar::register(
+            $this->router,
+            '/widgets',
+            $this->crud,
+            create: CreateWidget::class,
+            update: UpdateWidget::class,
+            search: SearchWidgets::class,
+        );
+    }
+
+    public function testAllFiveRoutesAreRegistered(): void
+    {
+        // Five routes, the documented shape. Calling match() on
+        // each verifies registration; the handlers themselves
+        // are tested elsewhere.
+        $this->assertNotNull($this->router->match('POST',   '/widgets'),    'POST /widgets must register');
+        $this->assertNotNull($this->router->match('GET',    '/widgets'),    'GET /widgets must register');
+        $this->assertNotNull($this->router->match('GET',    '/widgets/1'),  'GET /widgets/{id} must register');
+        $this->assertNotNull($this->router->match('PATCH',  '/widgets/1'),  'PATCH /widgets/{id} must register');
+        $this->assertNotNull($this->router->match('DELETE', '/widgets/1'),  'DELETE /widgets/{id} must register');
+    }
+
+    public function testIdConstraintRejectsNonIntByDefault(): void
+    {
+        // Default idType is 'int' → /widgets/abc must NOT match
+        // any registered route. Falls through to the framework's
+        // 404 handling.
+        $this->assertNull($this->router->match('GET', '/widgets/abc'));
+    }
+
+    public function testCreateRoundTripsThroughBinderToHandler(): void
+    {
+        $body     = ['name' => 'Widget', 'price' => 9, 'status' => 'published'];
+        $response = $this->invoke('POST', '/widgets', $body);
+
+        $this->assertSame(201, $response->getStatusCode());
+        $payload = $this->decode($response);
+        $this->assertSame('Widget', $payload['data']['name']);
+        $this->assertSame(9, $payload['data']['price']);
+        $this->assertSame('published', $payload['data']['status']);
+        $this->assertSame(1, $payload['data']['id']);
+    }
+
+    public function testCreateValidationFailureReturns422WithErrors(): void
+    {
+        $body     = ['name' => '', 'price' => -1, 'status' => 'weird'];
+        $response = $this->invoke('POST', '/widgets', $body);
+
+        $this->assertSame(422, $response->getStatusCode());
+        $this->assertSame('application/problem+json', $response->getHeaderLine('Content-Type'));
+        $payload = $this->decode($response);
+        $this->assertSame('Unprocessable Entity', $payload['title']);
+        $fields  = array_column($payload['errors'], 'field');
+        $this->assertContains('name', $fields);
+        $this->assertContains('price', $fields);
+        $this->assertContains('status', $fields);
+    }
+
+    public function testReadReturnsRowOrNullAsHandlerProvides(): void
+    {
+        $this->crud->create($this->buildCreate('Found', 5));
+
+        $found = $this->invoke('GET', '/widgets/1');
+        $this->assertSame(200, $found->getStatusCode());
+        $this->assertSame('Found', $this->decode($found)['data']['name']);
+
+        $missing = $this->invoke('GET', '/widgets/999');
+        $this->assertSame(404, $missing->getStatusCode());
+        $this->assertSame('Not Found', $this->decode($missing)['title']);
+    }
+
+    public function testUpdateMergesPartialFieldsOntoExistingRow(): void
+    {
+        $this->crud->create($this->buildCreate('Original', 10, 'draft'));
+
+        // PATCH only the name. Price / status stay as-is.
+        $response = $this->invoke('PATCH', '/widgets/1', ['name' => 'Renamed']);
+
+        $this->assertSame(200, $response->getStatusCode());
+        $payload = $this->decode($response);
+        $this->assertSame('Renamed', $payload['data']['name']);
+        $this->assertSame(10,        $payload['data']['price']);
+        $this->assertSame('draft',   $payload['data']['status']);
+    }
+
+    public function testUpdateOnMissingIdReturns404(): void
+    {
+        $response = $this->invoke('PATCH', '/widgets/999', ['name' => 'No-op']);
+        $this->assertSame(404, $response->getStatusCode());
+    }
+
+    public function testUpdateValidationFailureReturns422(): void
+    {
+        $this->crud->create($this->buildCreate('X', 1));
+
+        $response = $this->invoke('PATCH', '/widgets/1', ['status' => 'not-allowed']);
+        $this->assertSame(422, $response->getStatusCode());
+    }
+
+    public function testDeleteReturnsTrue204WithEmptyBody(): void
+    {
+        $this->crud->create($this->buildCreate('X', 1));
+
+        $response = $this->invoke('DELETE', '/widgets/1');
+        $this->assertSame(204, $response->getStatusCode());
+        // 204 No Content per HTTP spec — body must be empty,
+        // even though the framework's array envelope mapper would
+        // normally produce one.
+        $this->assertSame('', (string) $response->getBody());
+    }
+
+    public function testDeleteOnMissingIdReturns404(): void
+    {
+        $response = $this->invoke('DELETE', '/widgets/999');
+        $this->assertSame(404, $response->getStatusCode());
+    }
+
+    public function testSearchReturnsListWrappedInDataEnvelope(): void
+    {
+        $this->crud->create($this->buildCreate('Apple',  1, 'published'));
+        $this->crud->create($this->buildCreate('Banana', 2, 'published'));
+        $this->crud->create($this->buildCreate('Cherry', 3, 'draft'));
+
+        $response = $this->invoke('GET', '/widgets');
+        $this->assertSame(200, $response->getStatusCode());
+        $this->assertCount(3, $this->decode($response)['data']);
+    }
+
+    public function testSearchAppliesFilterFromQueryString(): void
+    {
+        $this->crud->create($this->buildCreate('Apple',  1, 'published'));
+        $this->crud->create($this->buildCreate('Banana', 2, 'published'));
+        $this->crud->create($this->buildCreate('Cherry', 3, 'draft'));
+
+        $response = $this->invoke('GET', '/widgets?status=draft');
+        $this->assertSame(200, $response->getStatusCode());
+        $rows = $this->decode($response)['data'];
+        $this->assertCount(1, $rows);
+        $this->assertSame('Cherry', $rows[0]['name']);
+    }
+
+    public function testSearchValidationFailureReturns422(): void
+    {
+        // SearchWidgets has #[InSet(['draft','published','archived'])]
+        // on $status. An out-of-set value rejects the request
+        // before search() runs.
+        $response = $this->invoke('GET', '/widgets?status=weird');
+        $this->assertSame(422, $response->getStatusCode());
+    }
+
+    public function testNullSearchDtoCallsHandlerWithNullFilter(): void
+    {
+        // A separate router + registration that omits the
+        // `search` arg. The handler receives null and returns
+        // every row (in-memory implementation's behaviour).
+        $router = new Router();
+        $crud   = new InMemoryWidgetCrud();
+        ResourceRegistrar::register(
+            $router,
+            '/items',
+            $crud,
+            create: CreateWidget::class,
+            update: UpdateWidget::class,
+        );
+        $crud->create($this->buildCreate('A', 1));
+        $crud->create($this->buildCreate('B', 2));
+
+        $hit = $router->match('GET', '/items');
+        $this->assertNotNull($hit);
+        $result = ($hit['handler'])(
+            $hit['params'],
+            new ServerRequest('GET', 'http://test/items'),
+        );
+        $this->assertCount(2, $result['data']);
+    }
+
+    public function testIdTypeUuidProducesStringIds(): void
+    {
+        // Custom idType → URL placeholder uses the constraint
+        // AND the handler receives a string id (not int-cast).
+        // Drive a fresh registration with idType: 'uuid'.
+        $router = new Router();
+        $captured = null;
+        $registrarHandler = new class($captured) implements \Rxn\Framework\Http\Resource\CrudHandler {
+            public function __construct(public mixed &$captured) {}
+            public function create(\Rxn\Framework\Http\Binding\RequestDto $dto): array { return []; }
+            public function read(int|string $id): ?array
+            {
+                $this->captured = $id;
+                return null;
+            }
+            public function update(int|string $id, \Rxn\Framework\Http\Binding\RequestDto $dto): ?array { return null; }
+            public function delete(int|string $id): bool { return false; }
+            public function search(?\Rxn\Framework\Http\Binding\RequestDto $filter): array { return []; }
+        };
+        ResourceRegistrar::register(
+            $router,
+            '/orgs',
+            $registrarHandler,
+            create: CreateWidget::class,
+            update: UpdateWidget::class,
+            idType: 'uuid',
+        );
+
+        // /orgs/abc would fail under default idType=int; with
+        // idType=uuid, only valid UUIDs match.
+        $this->assertNull(
+            $router->match('GET', '/orgs/not-a-uuid'),
+            'idType=uuid must reject non-UUID ids at the route level',
+        );
+
+        $hit = $router->match('GET', '/orgs/550e8400-e29b-41d4-a716-446655440000');
+        $this->assertNotNull($hit);
+        ($hit['handler'])($hit['params'], new ServerRequest('GET', 'http://test/'));
+
+        $this->assertIsString($registrarHandler->captured);
+        $this->assertSame('550e8400-e29b-41d4-a716-446655440000', $registrarHandler->captured);
+    }
+
+    /**
+     * Resolve a matched route + invoke its handler against a
+     * synthetic request, normalising the array vs ResponseInterface
+     * return into a uniform PSR-7 response (mirrors what
+     * `App::serve`'s default invoker does).
+     *
+     * @param array<string, mixed>|null $body  JSON body for
+     *        POST/PATCH. The Binder reads `$_POST` via
+     *        `gatherBag()` when called outside a request scope,
+     *        but in this test we drive Binder::bindRequest with
+     *        a real PSR-7 ServerRequest carrying parsedBody.
+     */
+    private function invoke(string $method, string $target, ?array $body = null): ResponseInterface
+    {
+        $uri    = parse_url($target);
+        $path   = $uri['path']  ?? $target;
+        $query  = $uri['query'] ?? '';
+
+        $hit = $this->router->match($method, $path);
+        $this->assertNotNull($hit, "$method $target did not match any route");
+
+        $request = new ServerRequest($method, "http://test{$target}");
+        if ($query !== '') {
+            parse_str($query, $params);
+            $request = $request->withQueryParams($params);
+        }
+        if ($body !== null) {
+            $request = $request->withParsedBody($body);
+        }
+
+        $result = ($hit['handler'])($hit['params'], $request);
+
+        if ($result instanceof ResponseInterface) {
+            return $result;
+        }
+        // Match App::arrayToPsrResponse — mirror its behaviour
+        // here so the test isn't coupled to App.
+        return self::wrap((array) $result);
+    }
+
+    /**
+     * Mirror of `App::arrayToPsrResponse` — kept local to the
+     * test so changes to App don't accidentally hide regressions
+     * here (and so the test runs without booting App).
+     *
+     * @param array<string, mixed> $body
+     */
+    private static function wrap(array $body): ResponseInterface
+    {
+        $status      = (int) ($body['meta']['status'] ?? 200);
+        $isFailure   = $status >= 400;
+        $contentType = $isFailure ? 'application/problem+json' : 'application/json';
+
+        $payload = $isFailure
+            ? array_filter([
+                'type'   => $body['meta']['type']   ?? 'about:blank',
+                'title'  => $body['meta']['title']  ?? '',
+                'status' => $status,
+                'errors' => $body['meta']['errors'] ?? null,
+            ], static fn ($v) => $v !== null)
+            : array_filter(
+                ['data' => $body['data'] ?? null, 'meta' => $body['meta'] ?? null],
+                static fn ($v) => $v !== null,
+            );
+        return new \Nyholm\Psr7\Response(
+            $status,
+            ['Content-Type' => $contentType],
+            json_encode($payload, JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR),
+        );
+    }
+
+    /** @return array<string, mixed> */
+    private function decode(ResponseInterface $r): array
+    {
+        return json_decode((string) $r->getBody(), true) ?? [];
+    }
+
+    private function buildCreate(string $name, int $price, string $status = 'draft'): CreateWidget
+    {
+        $dto = new CreateWidget();
+        $dto->name   = $name;
+        $dto->price  = $price;
+        $dto->status = $status;
+        return $dto;
+    }
+}

--- a/src/Rxn/Framework/Tests/Http/Resource/ResourceRegistrarTest.php
+++ b/src/Rxn/Framework/Tests/Http/Resource/ResourceRegistrarTest.php
@@ -396,6 +396,66 @@ final class ResourceRegistrarTest extends TestCase
         $this->assertNull($router->match('GET', '/widgets'));
     }
 
+    public function testPathWithoutLeadingSlashIsNormalized(): void
+    {
+        // Callers that omit the leading slash should produce the
+        // same routes as callers that include it.
+        $router = new Router();
+        ResourceRegistrar::register(
+            $router,
+            'no-slash',                 // ← missing leading /
+            new InMemoryWidgetCrud(),
+            create: CreateWidget::class,
+            update: UpdateWidget::class,
+        );
+
+        $this->assertNotNull($router->match('POST',   '/no-slash'),    'POST /no-slash must register');
+        $this->assertNotNull($router->match('GET',    '/no-slash'),    'GET /no-slash must register');
+        $this->assertNotNull($router->match('GET',    '/no-slash/1'),  'GET /no-slash/{id} must register');
+        $this->assertNotNull($router->match('PATCH',  '/no-slash/1'),  'PATCH /no-slash/{id} must register');
+        $this->assertNotNull($router->match('DELETE', '/no-slash/1'),  'DELETE /no-slash/{id} must register');
+    }
+
+    public function testRegisterThrowsOnInvalidCreateDtoClass(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+
+        ResourceRegistrar::register(
+            new Router(),
+            '/bad',
+            new InMemoryWidgetCrud(),
+            create: \stdClass::class,   // ← not a RequestDto
+            update: UpdateWidget::class,
+        );
+    }
+
+    public function testRegisterThrowsOnInvalidUpdateDtoClass(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+
+        ResourceRegistrar::register(
+            new Router(),
+            '/bad',
+            new InMemoryWidgetCrud(),
+            create: CreateWidget::class,
+            update: \stdClass::class,   // ← not a RequestDto
+        );
+    }
+
+    public function testRegisterThrowsOnInvalidSearchDtoClass(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+
+        ResourceRegistrar::register(
+            new Router(),
+            '/bad',
+            new InMemoryWidgetCrud(),
+            create: CreateWidget::class,
+            update: UpdateWidget::class,
+            search: \stdClass::class,   // ← not a RequestDto
+        );
+    }
+
     /**
      * Resolve a matched route + invoke its handler against a
      * synthetic request, normalising the array vs ResponseInterface

--- a/src/Rxn/Framework/Tests/Http/Resource/ResourceRegistrarTest.php
+++ b/src/Rxn/Framework/Tests/Http/Resource/ResourceRegistrarTest.php
@@ -456,6 +456,35 @@ final class ResourceRegistrarTest extends TestCase
         );
     }
 
+    public function testRegisterThrowsOnEmptyStringCreateDtoClass(): void
+    {
+        // Empty string would pass array_filter's default truthiness
+        // check (non-empty string is truthy), but '' is not a valid
+        // class name. Validation must catch it unconditionally.
+        $this->expectException(\InvalidArgumentException::class);
+
+        ResourceRegistrar::register(
+            new Router(),
+            '/bad',
+            new InMemoryWidgetCrud(),
+            create: '',                 // ← empty string, not a class
+            update: UpdateWidget::class,
+        );
+    }
+
+    public function testRegisterThrowsOnEmptyStringUpdateDtoClass(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+
+        ResourceRegistrar::register(
+            new Router(),
+            '/bad',
+            new InMemoryWidgetCrud(),
+            create: CreateWidget::class,
+            update: '',                 // ← empty string, not a class
+        );
+    }
+
     /**
      * Resolve a matched route + invoke its handler against a
      * synthetic request, normalising the array vs ResponseInterface

--- a/src/Rxn/Framework/Tests/Http/Resource/ResourceRegistrarTest.php
+++ b/src/Rxn/Framework/Tests/Http/Resource/ResourceRegistrarTest.php
@@ -485,6 +485,60 @@ final class ResourceRegistrarTest extends TestCase
         );
     }
 
+    public function testRegisterThrowsOnNonexistentDtoClass(): void
+    {
+        // A typo / removed-class case is functionally distinct from
+        // "exists but doesn't implement RequestDto" — the message
+        // must say "does not exist" so the operator knows whether
+        // to add a `use` import or fix the class hierarchy.
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessageMatches('/does not exist/');
+
+        ResourceRegistrar::register(
+            new Router(),
+            '/bad',
+            new InMemoryWidgetCrud(),
+            create: 'Acme\\NotARealClass',
+            update: UpdateWidget::class,
+        );
+    }
+
+    public function testRegisterThrowsOnIdTypeContainingInvalidCharacters(): void
+    {
+        // Router::compile() requires placeholder type identifiers to
+        // match [a-zA-Z_][a-zA-Z0-9_]*. The registrar validates the
+        // shape up front so a caller passing 'my-id' (or '' or
+        // '123id') gets a targeted error pointing at idType, not a
+        // generic "Malformed route placeholder" surfaced by Router
+        // pointing at the route's compile step.
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessageMatches('/idType/');
+
+        ResourceRegistrar::register(
+            new Router(),
+            '/bad',
+            new InMemoryWidgetCrud(),
+            create: CreateWidget::class,
+            update: UpdateWidget::class,
+            idType: 'my-id',  // hyphen not allowed by Router's grammar
+        );
+    }
+
+    public function testRegisterThrowsOnEmptyIdType(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessageMatches('/idType/');
+
+        ResourceRegistrar::register(
+            new Router(),
+            '/bad',
+            new InMemoryWidgetCrud(),
+            create: CreateWidget::class,
+            update: UpdateWidget::class,
+            idType: '',
+        );
+    }
+
     /**
      * Resolve a matched route + invoke its handler against a
      * synthetic request, normalising the array vs ResponseInterface


### PR DESCRIPTION
## Summary

Recovers the convention router's "extend a class, get five endpoints" ergonomic — without legacy AR baggage. One call wires a `CrudHandler` to the full five-route URL family; framework handles DTO binding, validation → 422, missing-row → 404, deleted → 204.

\`\`\`php
\$routes = ResourceRegistrar::register(
    \$router,
    '/products',
    new ProductsCrud(\$repo),
    create: CreateProduct::class,
    update: UpdateProduct::class,
    search: SearchProducts::class,
);
\`\`\`

After registration the router carries:

| Verb | Path | Handler call | Result |
|---|---|---|---|
| POST | `/products` | `create(\$dto)` | 201 / 422 |
| GET | `/products` | `search(\$filter)` | 200 (filter optional) |
| GET | `/products/{id:int}` | `read(\$id)` | 200 / 404 |
| PATCH | `/products/{id:int}` | `update(\$id, \$dto)` | 200 / 404 / 422 |
| DELETE | `/products/{id:int}` | `delete(\$id)` | 204 (empty body) / 404 |

## Middleware composition

The returned `ResourceRoutes` exposes the five `Route` handles so callers can attach middleware in three shapes:

\`\`\`php
// Group-based — RouteGroup inherits the group's prefix + middleware automatically.
\$router->group('/v1', function (RouteGroup \$g) use (\$auth) {
    \$g->middleware(\$auth);
    ResourceRegistrar::register(\$g, '/products', \$crud, /* … */);
});

// Resource-wide — chainable.
ResourceRegistrar::register(\$router, '/products', \$crud, /* … */)
    ->middleware(\$bearerAuth);

// Per-op — target the specific Route handle on the bag.
\$routes = ResourceRegistrar::register(\$router, '/products', \$crud, /* … */);
\$routes->update->middleware(\$adminOnly);
\$routes->delete->middleware(\$adminOnly);
\`\`\`

`register()` accepts either a `Router` or a `RouteGroup` as the first argument.

## Design

| Concern | Choice |
|---|---|
| Schema source | DTOs (typed wire). Future codegen step (`bin/rxn scaffold:from-table`) writes them from `information_schema` — schema-as-truth without runtime DB-at-boot coupling |
| Storage | Pluggable. Handler is a 5-method interface. `RxnOrmCrudHandler` base for relational, ~50 LOC for any other backend |
| Routing | Explicit `ResourceRegistrar::register()` — no magic URL convention. Routes are visible in the Router after registration |
| `idType` | `'int'` by default (URL placeholder + cast). `'uuid'` / `'slug'` / `'any'` / custom keeps the captured string |
| 204 vs envelope | `delete` returns a true PSR-7 204 with empty body (per HTTP spec) — registrar bypasses the array envelope mapper for that one case |
| Pagination | `Http\Middleware\Pagination`'s concern, not the handler's. Stack it on the search route via `\$routes->search->middleware(...)` for X-Total-Count + RFC 8288 Link headers |
| OpenAPI | Falls out for free — DTOs already drive the generator, CRUD operations just appear in the spec |

## What's NOT in this PR (deliberate scope cut, see horizons 1.6 follow-ups)

- **`RxnOrmCrudHandler`** abstract base — lives in [`davidwyly/rxn-orm`](https://github.com/davidwyly/rxn-orm). Reduces a relational handler to ~10 LOC. Follow-up PR on the rxn-orm repo.
- **`bin/rxn scaffold:from-table`** — codegen step that connects to the DB, reads `information_schema`, writes DTO files + handler stub. One-shot at scaffold time. Follow-up.
- **`#[Resource]` attribute** — alternative to explicit registration; would let `Scanner` discover resources at scan time. Useful but out-of-scope for the primitive.

## Tests

19 integration tests against an in-memory fixture (`Tests/Http/Resource/`):

- Registration shape — 5 routes registered with the documented HTTP methods + paths
- `idType=int` rejects non-integer ids at the route level
- Create round-trips through Binder to handler; bad body → 422 with errors[]
- Read 200 / 404 (handler returns `null` → 404 Problem Details)
- Update partial-field merge; 404 on missing; 422 on validation failure
- Delete 204 with truly empty body; 404 on missing
- Search 200 with full list; filter from query string; 422 on bad query
- Null search DTO → handler called with `null` filter
- `idType='uuid'` produces string IDs at the handler
- `register()` returns a `ResourceRoutes` value object (4 new tests)
- `ResourceRoutes::middleware()` applies to all five routes
- Per-op middleware composition through public Route fields
- `RouteGroup` registration inherits prefix + group middleware

## Files

\`\`\`
src/Rxn/Framework/Http/Resource/
├── CrudHandler.php          5-method interface
├── ResourceRegistrar.php    register() static + DTO binding + status-code mapping
└── ResourceRoutes.php       value object holding 5 Route handles + middleware() chainer

src/Rxn/Framework/Tests/Http/Resource/
├── ResourceRegistrarTest.php
└── Fixture/
    ├── CreateWidget.php          DTO with #[Required], #[Length], #[Min], #[InSet]
    ├── UpdateWidget.php          all-nullable DTO for partial updates
    ├── SearchWidgets.php         filter DTO with optional fields
    ├── InMemoryWidgetCrud.php    test-only handler implementation
    └── TagMiddleware.php         identity-checkable middleware for assertions

docs/horizons.md   theme 1.6 marked REALIZED (core)
docs/routing.md    new "CRUD resources — ResourceRegistrar" section + "Composing middleware" section; scaffold:from-table noted as future
README.md          novelty bullet
CHANGELOG.md       full Unreleased entry
\`\`\`

## Test plan

- [x] \`vendor/bin/phpunit --testsuite=framework\` — **661 / 1474 green** (was 642 / 1391; added 19)
- [x] \`php -l\` clean across all new files
- [x] \`composer validate --strict\` clean
- [x] No regressions in existing Router / Binder / OpenAPI tests