### PR TITLE
fix(codegen): refuse custom Validates attrs in polyparity exporter

### DIFF
--- a/src/Rxn/Framework/Codegen/PolyparityExporter.php
+++ b/src/Rxn/Framework/Codegen/PolyparityExporter.php
@@ -11,6 +11,7 @@ use Rxn\Framework\Http\Attribute\NotBlank;
 use Rxn\Framework\Http\Attribute\Required;
 use Rxn\Framework\Http\Attribute\Url;
 use Rxn\Framework\Http\Binding\RequestDto;
+use Rxn\Framework\Http\Binding\Validates;
 
 /**
  * Emit a polyparity YAML spec from a Rxn `RequestDto`. The same
@@ -212,6 +213,15 @@ final class PolyparityExporter
                 . 'Add a mapping or document the DTO as PHP-only.',
             );
         }
+
+        if (is_subclass_of($attrName, Validates::class)) {
+            throw new \RuntimeException(
+                "PolyparityExporter: $attrName on property '$propName' is a custom validator. "
+                . 'Refusing to emit silently-divergent spec. '
+                . 'Add a polyparity mapping or keep this DTO PHP-only.'
+            );
+        }
+
         return null;
     }
 

--- a/src/Rxn/Framework/Tests/Codegen/PolyparityExporterTest.php
+++ b/src/Rxn/Framework/Tests/Codegen/PolyparityExporterTest.php
@@ -183,6 +183,14 @@ final class PolyparityExporterTest extends TestCase
         $exporter->emit(Fixture\UnsupportedDto::class);
     }
 
+
+    public function testRefusesCustomValidatesAttribute(): void
+    {
+        $exporter = new PolyparityExporter();
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessageMatches('/CustomValidatesAttribute.*custom validator/i');
+        $exporter->emit(Fixture\CustomUnsupportedDto::class);
+    }
     public function testRejectsNonRequestDto(): void
     {
         $exporter = new PolyparityExporter();


### PR DESCRIPTION
### Motivation
- The `PolyparityExporter` previously omitted unknown validation attributes from the generated YAML, which can silently diverge from the PHP `Binder` that executes any attribute implementing `Validates`; this creates a risk when generated specs are used as enforcement points in other runtimes.

### Description
- Updated `src/Rxn/Framework/Codegen/PolyparityExporter.php` to `use Rxn\Framework\Http\Binding\Validates` and make `refuse()` explicitly detect attributes that implement `Validates` and throw a `RuntimeException` instead of returning `null`.
- Preserved the existing refusal behavior for known unsupported built-ins (`Pattern`, `Uuid`, `Json`, `Date`, `StartsWith`, `EndsWith`).
- Added a regression test `testRefusesCustomValidatesAttribute()` to `src/Rxn/Framework/Tests/Codegen/PolyparityExporterTest.php` that asserts the exporter refuses DTOs using a custom `Validates` attribute.

### Testing
- Added a unit test `PolyparityExporterTest::testRefusesCustomValidatesAttribute()` covering the new refusal behavior; the test is included in the repo but was not executed successfully in this environment.
- Attempted to run `phpunit` directly (`php -d zend.assertions=1 ./vendor/bin/phpunit src/Rxn/Framework/Tests/Codegen/PolyparityExporterTest.php`) and via `composer test`, but both attempts failed because `phpunit` is not available in the execution environment (`phpunit: not found`).
- No other automated test failures were observed locally in this environment (test tooling unavailable to run the full suite).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f7a3a0ac34832fac57b9f3bc1a4b75)